### PR TITLE
DependencyVulnerabilityCheck does not bump `major.minor` version schemes

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
@@ -84,9 +84,10 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
     public String getDescription() {
         //language=markdown
         return "This is a software composition analysis (SCA) tool which detects publicly disclosed vulnerabilities. " +
-               "If vulnerabilities are found, it will generate a report linking to the associated CVE entries. " +
-               "Vulnerability information comes from the [GitHub Security Advisory Database](https://docs.github.com/en/code-security/security-advisories/global-security-advisories/about-the-github-advisory-database), " +
-               "which aggregates vulnerability data from several public databases, including the [National Vulnerability Database](https://nvd.nist.gov/) maintained by the United States government.";
+                "If vulnerabilities are found, it will generate a report linking to the associated CVE entries. " +
+                "Vulnerability information comes from the [GitHub Security Advisory Database](https://docs.github.com/en/code-security/security-advisories/global-security-advisories/about-the-github-advisory-database), " +
+                "which aggregates vulnerability data from several public databases, including the [National Vulnerability Database](https://nvd.nist.gov/) maintained by the United States government. " +
+                "Dependencies following [Semantic Versioning](https://semver.org/) will see their _patch_ version updated where applicable.";
     }
 
     @Override
@@ -241,8 +242,8 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
         };
     }
 
-        private static boolean scopeExcludesConfiguration(GradleDependencyConfiguration configuration, Scope scope) {
-        switch(scope) {
+    private static boolean scopeExcludesConfiguration(GradleDependencyConfiguration configuration, Scope scope) {
+        switch (scope) {
             case Test:
                 return !configuration.getName().contains("test");
             case Compile:
@@ -347,7 +348,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                                     GroupArtifact ga = new GroupArtifact(gav.getGroupId(), gav.getArtifactId());
                                     String fixVersion = fixes.get(ga);
                                     if (!StringUtils.isBlank(v.getFixedVersion()) &&
-                                        new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion())) {
+                                            new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion())) {
                                         if (fixVersion == null || new StaticVersionComparator().compare(versionParser.transform(v.getFixedVersion()), versionParser.transform(fixVersion)) > 0) {
                                             fixes.put(ga, v.getFixedVersion());
                                         }
@@ -356,14 +357,14 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
 
                                 if (vulnerable && Boolean.TRUE.equals(addMarkers)) {
                                     return SearchResult.found(tag, "This dependency includes " + gav + " which has the following vulnerabilities:\n" +
-                                                                   vulnerabilitiesByGav.getValue().stream()
-                                                                           .map(vDepth -> {
-                                                                               Vulnerability v = vDepth.getVulnerability();
-                                                                               return v.getCve() + " (" + v.getSeverity() + " severity" +
-                                                                                      (StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion()) +
-                                                                                      ") - " + v.getSummary();
-                                                                           })
-                                                                           .collect(Collectors.joining("\n")));
+                                            vulnerabilitiesByGav.getValue().stream()
+                                                    .map(vDepth -> {
+                                                        Vulnerability v = vDepth.getVulnerability();
+                                                        return v.getCve() + " (" + v.getSeverity() + " severity" +
+                                                                (StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion()) +
+                                                                ") - " + v.getSummary();
+                                                    })
+                                                    .collect(Collectors.joining("\n")));
                                 }
                             }
                         }
@@ -389,14 +390,14 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                     ResolvedGroupArtifactVersion gav = vulnerabilitiesByGav.getKey();
                     if (Boolean.TRUE.equals(addMarkers)) {
                         c = SearchResult.found(c, "This project has the following vulnerabilities:\n" +
-                                                  vulnerabilitiesByGav.getValue().stream()
-                                                          .map(vDepth -> {
-                                                              Vulnerability v = vDepth.getVulnerability();
-                                                              return "Dependency " + gav + " has " + v.getCve() + " (" + v.getSeverity() + " severity" +
-                                                                     (StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion()) +
-                                                                     ") - " + v.getSummary();
-                                                          })
-                                                          .collect(Collectors.joining("\n")));
+                                vulnerabilitiesByGav.getValue().stream()
+                                        .map(vDepth -> {
+                                            Vulnerability v = vDepth.getVulnerability();
+                                            return "Dependency " + gav + " has " + v.getCve() + " (" + v.getSeverity() + " severity" +
+                                                    (StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion()) +
+                                                    ") - " + v.getSummary();
+                                        })
+                                        .collect(Collectors.joining("\n")));
                     }
                     for (GradleDependencyConfiguration configuration : gp.getConfigurations()) {
                         if (scopeExcludesConfiguration(configuration, aScope) || !configuration.isCanBeResolved()) {
@@ -404,8 +405,8 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                         }
                         List<ResolvedDependency> resolved = configuration.getResolved();
                         for (ResolvedDependency resolvedDependency : resolved) {
-                            if(Objects.equals(resolvedDependency.getGroupId(), gav.getGroupId())
-                               && Objects.equals(resolvedDependency.getArtifactId(), gav.getArtifactId())) {
+                            if (Objects.equals(resolvedDependency.getGroupId(), gav.getGroupId())
+                                    && Objects.equals(resolvedDependency.getArtifactId(), gav.getArtifactId())) {
 
                                 for (MinimumDepthVulnerability vDepth : vulnerabilitiesByGav.getValue()) {
                                     Vulnerability v = vDepth.getVulnerability();
@@ -413,7 +414,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                                     GroupArtifact ga = new GroupArtifact(gav.getGroupId(), gav.getArtifactId());
                                     String fixVersion = fixes.get(ga);
                                     if (!StringUtils.isBlank(v.getFixedVersion()) &&
-                                        new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion())) {
+                                            new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion())) {
                                         if (fixVersion == null || new StaticVersionComparator().compare(versionParser.transform(v.getFixedVersion()), versionParser.transform(fixVersion)) > 0) {
                                             fixes.put(ga, v.getFixedVersion());
                                         }

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
@@ -124,10 +124,10 @@ public class DependencyVulnerabilityCheckTest implements RewriteTest {
     }
 
     @Test
-    void mavenScopeCompile() {
+    void mavenSnakeyamlMajorMinor() {
         rewriteRun(
           spec -> spec
-            .recipe(new DependencyVulnerabilityCheck("Compile", true, false)),
+            .recipe(new DependencyVulnerabilityCheck("compile", false, false)),
           //language=xml
           pomXml(
             """
@@ -138,24 +138,13 @@ public class DependencyVulnerabilityCheckTest implements RewriteTest {
               	<groupId>com.example</groupId>
               	<artifactId>openrewrite-playground</artifactId>
               	<version>0.0.1-SNAPSHOT</version>
-              	<properties>
-              		<snakeyaml.version>1.29</snakeyaml.version>
-              	</properties>
               	<dependencies>
               		<dependency>
               			<groupId>org.yaml</groupId>
               			<artifactId>snakeyaml</artifactId>
+              			<version>1.29</version>
               		</dependency>
               	</dependencies>
-              	<dependencyManagement>
-              		<dependencies>
-              			<dependency>
-              				<groupId>org.yaml</groupId>
-              				<artifactId>snakeyaml</artifactId>
-              				<version>${snakeyaml.version}</version>
-              			</dependency>
-              		</dependencies>
-              	</dependencyManagement>
               </project>
               """,
             """
@@ -166,24 +155,58 @@ public class DependencyVulnerabilityCheckTest implements RewriteTest {
               	<groupId>com.example</groupId>
               	<artifactId>openrewrite-playground</artifactId>
               	<version>0.0.1-SNAPSHOT</version>
-              	<properties>
-              		<snakeyaml.version>1.33</snakeyaml.version>
-              	</properties>
               	<dependencies>
               		<dependency>
               			<groupId>org.yaml</groupId>
               			<artifactId>snakeyaml</artifactId>
+              			<version>1.33</version>
               		</dependency>
               	</dependencies>
-              	<dependencyManagement>
-              		<dependencies>
-              			<dependency>
-              				<groupId>org.yaml</groupId>
-              				<artifactId>snakeyaml</artifactId>
-              				<version>${snakeyaml.version}</version>
-              			</dependency>
-              		</dependencies>
-              	</dependencyManagement>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void mavenJacksonMajorMinorPatch() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new DependencyVulnerabilityCheck("compile", false, false)),
+          //language=xml
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+              	<modelVersion>4.0.0</modelVersion>
+              	<groupId>com.example</groupId>
+              	<artifactId>openrewrite-playground</artifactId>
+              	<version>0.0.1-SNAPSHOT</version>
+              	<dependencies>
+              		<dependency>
+              			<groupId>com.fasterxml.jackson.core</groupId>
+              			<artifactId>jackson-databind</artifactId>
+              			<version>2.13.0</version>
+              		</dependency>
+              	</dependencies>
+              </project>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+              	<modelVersion>4.0.0</modelVersion>
+              	<groupId>com.example</groupId>
+              	<artifactId>openrewrite-playground</artifactId>
+              	<version>0.0.1-SNAPSHOT</version>
+              	<dependencies>
+              		<dependency>
+              			<groupId>com.fasterxml.jackson.core</groupId>
+              			<artifactId>jackson-databind</artifactId>
+              			<version>2.13.4.1</version>
+              		</dependency>
+              	</dependencies>
               </project>
               """
           )

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.dependencies;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.dependencies.table.VulnerabilityReport;
 import org.openrewrite.test.RecipeSpec;
@@ -124,6 +125,7 @@ public class DependencyVulnerabilityCheckTest implements RewriteTest {
     }
 
     @Test
+    @Disabled("https://github.com/openrewrite/rewrite-java-dependencies/pull/7") // major.minor not supported yet
     void mavenSnakeyamlMajorMinor() {
         rewriteRun(
           spec -> spec

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
@@ -56,7 +56,7 @@ public class DependencyVulnerabilityCheckTest implements RewriteTest {
               Dependency org.apache.logging.log4j:log4j:2.13.1 has CVE-2020-9488 (LOW severity, fixed in 2.13.2) - Improper validation of certificate with host mismatch in Apache Log4j SMTP appender)~~>*/plugins {
                 id 'java'
               }
-              
+                            
               repositories {
                   mavenCentral()
               }
@@ -117,6 +117,73 @@ public class DependencyVulnerabilityCheckTest implements RewriteTest {
                     <version>2.13.2</version>
                   </dependency>
                 </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void mavenScopeCompile() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new DependencyVulnerabilityCheck("Compile", true, false)),
+          //language=xml
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+              	<modelVersion>4.0.0</modelVersion>
+              	<groupId>com.example</groupId>
+              	<artifactId>openrewrite-playground</artifactId>
+              	<version>0.0.1-SNAPSHOT</version>
+              	<properties>
+              		<snakeyaml.version>1.29</snakeyaml.version>
+              	</properties>
+              	<dependencies>
+              		<dependency>
+              			<groupId>org.yaml</groupId>
+              			<artifactId>snakeyaml</artifactId>
+              		</dependency>
+              	</dependencies>
+              	<dependencyManagement>
+              		<dependencies>
+              			<dependency>
+              				<groupId>org.yaml</groupId>
+              				<artifactId>snakeyaml</artifactId>
+              				<version>${snakeyaml.version}</version>
+              			</dependency>
+              		</dependencies>
+              	</dependencyManagement>
+              </project>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+              	<modelVersion>4.0.0</modelVersion>
+              	<groupId>com.example</groupId>
+              	<artifactId>openrewrite-playground</artifactId>
+              	<version>0.0.1-SNAPSHOT</version>
+              	<properties>
+              		<snakeyaml.version>1.33</snakeyaml.version>
+              	</properties>
+              	<dependencies>
+              		<dependency>
+              			<groupId>org.yaml</groupId>
+              			<artifactId>snakeyaml</artifactId>
+              		</dependency>
+              	</dependencies>
+              	<dependencyManagement>
+              		<dependencies>
+              			<dependency>
+              				<groupId>org.yaml</groupId>
+              				<artifactId>snakeyaml</artifactId>
+              				<version>${snakeyaml.version}</version>
+              			</dependency>
+              		</dependencies>
+              	</dependencyManagement>
               </project>
               """
           )


### PR DESCRIPTION
## What's changed?
Tests to replicate issue with DependencyVulnerabilityCheck as reported via Slack:
https://rewriteoss.slack.com/archives/C01A843MWG5/p1685635464607779?thread_ts=1685556511.929269&cid=C01A843MWG5

The snakeyaml test now fails due to this `LatestPatch` restriction in the recipe:
https://github.com/openrewrite/rewrite-java-dependencies/blob/5034484c423ab2ebc0194489dad9a320128234fc/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java#L349-L352

## What's your motivation?
Looking at this sampling of Spring Boot managed dependencies:
https://docs.spring.io/spring-boot/docs/current/reference/html/dependency-versions.html
We now fail to support bumps to these dependencies:
```
com.graphql-java:graphql-java:20.2
com.samskivert:jmustache:1.15
commons-codec:commons-codec:1.15
commons-pool:commons-pool:1.6
javax.money:money-api:1.1
org.hamcrest:hamcrest:2.2
org.hamcrest:hamcrest-core:2.2
org.hamcrest:hamcrest-library:2.2
org.influxdb:influxdb-java:2.23
org.webjars:webjars-locator-core:0.52
org.yaml:snakeyaml:1.33
```
Which while granted isn't a huge list, it still contains Snakeyaml, which recently had some public vulnerabilities.

## Have you considered any alternatives or workarounds?
We could either have the recipe support broader updates (with risks tied to that as well),
or document the fact that the recipe has this major.minor.patch restriction clearly.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
