### PR TITLE
Moved instantiation to getRecipeList

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/ChangeDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/ChangeDependency.java
@@ -16,13 +16,18 @@
 package org.openrewrite.java.dependencies;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.internal.lang.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
+@Getter
+@RequiredArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class ChangeDependency extends Recipe {
     // Gradle and Maven shared parameters
@@ -82,31 +87,24 @@ public class ChangeDependency extends Recipe {
         return "Change the groupId, artifactId and/or the version of a specified Gradle or Maven dependency.";
     }
 
-    private final org.openrewrite.gradle.ChangeDependency changeGradleDependency;
-    private final org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId changeMavenDependency;
-
-    public ChangeDependency(
-            String oldGroupId,
-            String oldArtifactId,
-            @Nullable String newGroupId,
-            @Nullable String newArtifactId,
-            @Nullable String newVersion,
-            @Nullable String versionPattern,
-            @Nullable Boolean overrideManagedVersion
-    ) {
-        this.oldGroupId = oldGroupId;
-        this.oldArtifactId = oldArtifactId;
-        this.newGroupId = newGroupId;
-        this.newArtifactId = newArtifactId;
-        this.newVersion = newVersion;
-        this.versionPattern = versionPattern;
-        this.overrideManagedVersion = overrideManagedVersion;
-        changeGradleDependency = new org.openrewrite.gradle.ChangeDependency(oldGroupId, oldArtifactId, newGroupId, newArtifactId, newVersion, versionPattern);
-        changeMavenDependency = new org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId(oldGroupId, oldArtifactId, newGroupId, newArtifactId, newVersion, versionPattern, overrideManagedVersion);
-    }
+    @Nullable
+    private transient org.openrewrite.gradle.ChangeDependency changeGradleDependency;
+    @Nullable
+    private transient org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId changeMavenDependency;
 
     @Override
     public List<Recipe> getRecipeList() {
+        if (changeGradleDependency == null ||
+                !Objects.equals(changeGradleDependency.getOldGroupId(), oldGroupId) ||
+                !Objects.equals(changeGradleDependency.getOldArtifactId(), oldArtifactId) ||
+                !Objects.equals(changeGradleDependency.getNewGroupId(), newGroupId) ||
+                !Objects.equals(changeGradleDependency.getNewArtifactId(), newArtifactId) ||
+                !Objects.equals(changeGradleDependency.getNewVersion(), newVersion) ||
+                !Objects.equals(changeGradleDependency.getVersionPattern(), versionPattern)
+        ) {
+            changeGradleDependency = new org.openrewrite.gradle.ChangeDependency(oldGroupId, oldArtifactId, newGroupId, newArtifactId, newVersion, versionPattern);
+            changeMavenDependency = new org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId(oldGroupId, oldArtifactId, newGroupId, newArtifactId, newVersion, versionPattern, overrideManagedVersion);
+        }
         return Arrays.asList(
                 changeGradleDependency,
                 changeMavenDependency

--- a/src/test/java/org/openrewrite/java/dependencies/ChangeDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/ChangeDependencyTest.java
@@ -106,4 +106,44 @@ class ChangeDependencyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotPinWhenNotVersioned() {
+        rewriteRun(
+          spec -> spec
+            .beforeRecipe(withToolingApi())
+            .recipe(new ChangeDependency("mysql", "mysql-connector-java", "com.mysql", "mysql-connector-j", "8.0.x", null, null)),
+          buildGradle(
+            """
+              plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.6.1'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+              }
+              
+              repositories {
+                 mavenCentral()
+              }
+              
+              dependencies {
+                  runtimeOnly 'mysql:mysql-connector-java'
+              }
+              """,
+            """
+              plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.6.1'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+              }
+              
+              repositories {
+                 mavenCentral()
+              }
+              
+              dependencies {
+                  runtimeOnly 'com.mysql:mysql-connector-j'
+              }
+              """)
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Moved the logic of instantiating the children recipes to getRecipeList to avoid issues with default parameters. Also removed the constructor and replaced it by lombok RequiredArgsConstructor.

Added a test to validate the behavior of the recipe with unpinned versions on gradle side (was failing before on another repo that uses this recipe)

## What's your motivation?
This recipe is being used by rewrite-spring, and was not producing the expected results, probably due to wrong parameters pushed to child recipes when being instantiated form a declarative recipe (yml)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
