### PR TITLE
Use non deprecated constructor

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/ChangeDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/ChangeDependency.java
@@ -70,7 +70,6 @@ public class ChangeDependency extends Recipe {
     @Nullable
     private final String versionPattern;
 
-    // Maven only parameters
     @Option(displayName = "Override managed version",
             description = "If the new dependency has a managed version, this flag can be used to explicitly set the version on the dependency. The default for this flag is `false`.",
             required = false)
@@ -102,7 +101,7 @@ public class ChangeDependency extends Recipe {
                 !Objects.equals(changeGradleDependency.getNewVersion(), newVersion) ||
                 !Objects.equals(changeGradleDependency.getVersionPattern(), versionPattern)
         ) {
-            changeGradleDependency = new org.openrewrite.gradle.ChangeDependency(oldGroupId, oldArtifactId, newGroupId, newArtifactId, newVersion, versionPattern);
+            changeGradleDependency = new org.openrewrite.gradle.ChangeDependency(oldGroupId, oldArtifactId, newGroupId, newArtifactId, newVersion, versionPattern, overrideManagedVersion);
             changeMavenDependency = new org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId(oldGroupId, oldArtifactId, newGroupId, newArtifactId, newVersion, versionPattern, overrideManagedVersion);
         }
         return Arrays.asList(

--- a/src/test/java/org/openrewrite/java/dependencies/ChangeDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/ChangeDependencyTest.java
@@ -108,7 +108,7 @@ class ChangeDependencyTest implements RewriteTest {
     }
 
     @Test
-    void doNotPinWhenNotVersioned() {
+    void doNotPinWhenNotVersionedGradle() {
         rewriteRun(
           spec -> spec
             .beforeRecipe(withToolingApi())
@@ -142,6 +142,46 @@ class ChangeDependencyTest implements RewriteTest {
               
               dependencies {
                   runtimeOnly 'com.mysql:mysql-connector-j'
+              }
+              """)
+        );
+    }
+
+    @Test
+    void pinWhenOverrideManagedVersionGradle() {
+        rewriteRun(
+          spec -> spec
+            .beforeRecipe(withToolingApi())
+            .recipe(new ChangeDependency("mysql", "mysql-connector-java", "com.mysql", "mysql-connector-j", "8.0.x", null, true)),
+          buildGradle(
+            """
+              plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.6.1'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+              }
+              
+              repositories {
+                 mavenCentral()
+              }
+              
+              dependencies {
+                  runtimeOnly 'mysql:mysql-connector-java'
+              }
+              """,
+            """
+              plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.6.1'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+              }
+              
+              repositories {
+                 mavenCentral()
+              }
+              
+              dependencies {
+                  runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
               }
               """)
         );


### PR DESCRIPTION
## What's changed?
Using the new non-deprecated constructor that recives overrideManagedVersion parameter
