### PR TITLE
Limit `fixWithVersionUpdateOnly` to depth zero dependencies

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
@@ -174,7 +174,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
             for (MinimumDepthVulnerability vDepth : vulnerabilitiesByGav.getValue()) {
                 Vulnerability v = vDepth.getVulnerability();
                 ResolvedGroupArtifactVersion gav = vulnerabilitiesByGav.getKey();
-                boolean fixWithVersionUpdateOnly = vDepth.getMinDepth() == 0
+                boolean fixWithVersionUpdateOnly = (vDepth.getMinDepth() == 0 || Boolean.TRUE.equals(overrideManagedVersion))
                         && new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion());
                 report.insertRow(ctx, new VulnerabilityReport.Row(
                         v.getCve(),

--- a/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
@@ -84,15 +84,15 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
     public String getDescription() {
         //language=markdown
         return "This software composition analysis (SCA) tool detects and upgrades dependencies with publicly disclosed vulnerabilities. " +
-               "This recipe both generates a report of vulnerable dependencies and upgrades to newer versions with fixes. " +
-               "Automatic upgrade of vulnerable versions is performed when the fixed version is a minor or patch version bump. " +
-               "Vulnerability information comes from the [GitHub Security Advisory Database](https://docs.github.com/en/code-security/security-advisories/global-security-advisories/about-the-github-advisory-database), " +
-               "which aggregates vulnerability data from several public databases, including the [National Vulnerability Database](https://nvd.nist.gov/) maintained by the United States government. " +
-               "Dependencies following [Semantic Versioning](https://semver.org/) will see their _patch_ version updated where applicable.";
+                "This recipe both generates a report of vulnerable dependencies and upgrades to newer versions with fixes. " +
+                "Automatic upgrade of vulnerable versions is performed when the fixed version is a minor or patch version bump. " +
+                "Vulnerability information comes from the [GitHub Security Advisory Database](https://docs.github.com/en/code-security/security-advisories/global-security-advisories/about-the-github-advisory-database), " +
+                "which aggregates vulnerability data from several public databases, including the [National Vulnerability Database](https://nvd.nist.gov/) maintained by the United States government. " +
+                "Dependencies following [Semantic Versioning](https://semver.org/) will see their _patch_ version updated where applicable.";
     }
 
     @Override
-    public Validated validate() {
+    public Validated<Object> validate() {
         return super.validate().and(Validated.test("scope", "scope is a valid Maven scope", scope, s -> {
             try {
                 Scope.fromName(s);
@@ -174,7 +174,8 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
             for (MinimumDepthVulnerability vDepth : vulnerabilitiesByGav.getValue()) {
                 Vulnerability v = vDepth.getVulnerability();
                 ResolvedGroupArtifactVersion gav = vulnerabilitiesByGav.getKey();
-                boolean fixWithVersionUpdateOnly = new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion());
+                boolean fixWithVersionUpdateOnly = vDepth.getMinDepth() == 0
+                        && new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion());
                 report.insertRow(ctx, new VulnerabilityReport.Row(
                         v.getCve(),
                         gav.getGroupId(),
@@ -351,7 +352,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                                     GroupArtifact ga = new GroupArtifact(gav.getGroupId(), gav.getArtifactId());
                                     String fixVersion = fixes.get(ga);
                                     if (!StringUtils.isBlank(v.getFixedVersion()) &&
-                                        new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion())) {
+                                            new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion())) {
                                         if (fixVersion == null || new StaticVersionComparator().compare(versionParser.transform(v.getFixedVersion()), versionParser.transform(fixVersion)) > 0) {
                                             fixes.put(ga, v.getFixedVersion());
                                         }
@@ -360,14 +361,14 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
 
                                 if (vulnerable && Boolean.TRUE.equals(addMarkers)) {
                                     return SearchResult.found(tag, "This dependency includes " + gav + " which has the following vulnerabilities:\n" +
-                                                                   vulnerabilitiesByGav.getValue().stream()
-                                                                           .map(vDepth -> {
-                                                                               Vulnerability v = vDepth.getVulnerability();
-                                                                               return v.getCve() + " (" + v.getSeverity() + " severity" +
-                                                                                      (StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion()) +
-                                                                                      ") - " + v.getSummary();
-                                                                           })
-                                                                           .collect(Collectors.joining("\n")));
+                                            vulnerabilitiesByGav.getValue().stream()
+                                                    .map(vDepth -> {
+                                                        Vulnerability v = vDepth.getVulnerability();
+                                                        return v.getCve() + " (" + v.getSeverity() + " severity" +
+                                                                (StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion()) +
+                                                                ") - " + v.getSummary();
+                                                    })
+                                                    .collect(Collectors.joining("\n")));
                                 }
                             }
                         }
@@ -393,14 +394,14 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                     ResolvedGroupArtifactVersion gav = vulnerabilitiesByGav.getKey();
                     if (Boolean.TRUE.equals(addMarkers)) {
                         c = SearchResult.found(c, "This project has the following vulnerabilities:\n" +
-                                                  vulnerabilitiesByGav.getValue().stream()
-                                                          .map(vDepth -> {
-                                                              Vulnerability v = vDepth.getVulnerability();
-                                                              return "Dependency " + gav + " has " + v.getCve() + " (" + v.getSeverity() + " severity" +
-                                                                     (StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion()) +
-                                                                     ") - " + v.getSummary();
-                                                          })
-                                                          .collect(Collectors.joining("\n")));
+                                vulnerabilitiesByGav.getValue().stream()
+                                        .map(vDepth -> {
+                                            Vulnerability v = vDepth.getVulnerability();
+                                            return "Dependency " + gav + " has " + v.getCve() + " (" + v.getSeverity() + " severity" +
+                                                    (StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion()) +
+                                                    ") - " + v.getSummary();
+                                        })
+                                        .collect(Collectors.joining("\n")));
                     }
                     for (GradleDependencyConfiguration configuration : gp.getConfigurations()) {
                         if (scopeExcludesConfiguration(configuration, aScope) || !configuration.isCanBeResolved()) {
@@ -409,7 +410,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                         List<ResolvedDependency> resolved = configuration.getResolved();
                         for (ResolvedDependency resolvedDependency : resolved) {
                             if (Objects.equals(resolvedDependency.getGroupId(), gav.getGroupId())
-                                && Objects.equals(resolvedDependency.getArtifactId(), gav.getArtifactId())) {
+                                    && Objects.equals(resolvedDependency.getArtifactId(), gav.getArtifactId())) {
 
                                 for (MinimumDepthVulnerability vDepth : vulnerabilitiesByGav.getValue()) {
                                     Vulnerability v = vDepth.getVulnerability();
@@ -417,7 +418,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                                     GroupArtifact ga = new GroupArtifact(gav.getGroupId(), gav.getArtifactId());
                                     String fixVersion = fixes.get(ga);
                                     if (!StringUtils.isBlank(v.getFixedVersion()) &&
-                                        new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion())) {
+                                            new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion())) {
                                         if (fixVersion == null || new StaticVersionComparator().compare(versionParser.transform(v.getFixedVersion()), versionParser.transform(fixVersion)) > 0) {
                                             fixes.put(ga, v.getFixedVersion());
                                         }


### PR DESCRIPTION
## What's changed?
Limit when `fixWithVersionUpdateOnly` is reported as true, as we were a bit too eager for transitive dependencies that might require more work, as outlined in #5 

## What's your motivation?
Fixes #5

## Anything in particular you'd like reviewers to focus on?
We were too liberal before; are we too restrictive now?