### PR TITLE
Remove expired suppressions from DependencyCheck xml files

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/RemoveExpiredSuppressions.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveExpiredSuppressions.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.dependencies;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.XmlIsoVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public class RemoveExpiredSuppressions extends Recipe {
+    private static final XPathMatcher X_PATH_MATCHER = new XPathMatcher("/suppressions/suppress");
+
+    @Override
+    public String getDisplayName() {
+        return "Remove expired suppressions";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove expired vulnerability suppressions from `DependencyCheck` `suppression.xml` files.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new XmlIsoVisitor<ExecutionContext>() {
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = super.visitTag(tag, ctx);
+                if (X_PATH_MATCHER.matches(getCursor())) {
+                    Optional<Xml.Attribute> untilAttribute = t.getAttributes().stream()
+                            .filter(attribute -> "until".equals(attribute.getKeyAsString()))
+                            .findFirst();
+                    if (untilAttribute.isPresent()) {
+                        String until = untilAttribute.get().getValue().getValue();
+                        if (LocalDate.parse(until.substring(0, 10)).isBefore(LocalDate.now())) {
+                            return null;
+                        }
+                    }
+                }
+                return t;
+            }
+        };
+    }
+}

--- a/src/test/java/org/openrewrite/java/dependencies/RemoveExpiredSuppressionsTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RemoveExpiredSuppressionsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.dependencies;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+class RemoveExpiredSuppressionsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveExpiredSuppressions());
+    }
+
+    @Test
+    @DocumentExample
+    @Issue("https://github.com/openrewrite/rewrite-java-dependencies/issues/24")
+    void removeExpiredSuppressions() {
+        rewriteRun(
+          //language=XML
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+                  <suppress until="2023-05-19Z">
+                      <notes><![CDATA[
+                      file name: woodstox-core-6.3.1.jar
+                      Severity: HIGH
+                      False positive. We do not use woodstox and it will be updated with the next spring cloud
+                      dependencies.
+                  ]]></notes>
+                      <packageUrl regex="true">^pkg:maven/com\\.fasterxml\\.woodstox/woodstox\\-core@.*$</packageUrl>
+                      <vulnerabilityName>CVE-2022-40152</vulnerabilityName>
+                  </suppress>
+                  <suppress until="3000-01-01Z">
+                      <notes><![CDATA[
+                          file name: jackson-databind-2.15.2.jar
+                          This is not a really valid CVE and not really exploitable as Java code needs to be modified: https://github.com/FasterXML/jackson-databind/issues/3972
+                      ]]></notes>
+                      <packageUrl regex="true">^pkg:maven/com\\.fasterxml\\.jackson\\.core/jackson\\-databind@.*$</packageUrl>
+                      <cve>CVE-2023-35116</cve>
+                  </suppress>
+              </suppressions>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+                  <suppress until="3000-01-01Z">
+                      <notes><![CDATA[
+                          file name: jackson-databind-2.15.2.jar
+                          This is not a really valid CVE and not really exploitable as Java code needs to be modified: https://github.com/FasterXML/jackson-databind/issues/3972
+                      ]]></notes>
+                      <packageUrl regex="true">^pkg:maven/com\\.fasterxml\\.jackson\\.core/jackson\\-databind@.*$</packageUrl>
+                      <cve>CVE-2023-35116</cve>
+                  </suppress>
+              </suppressions>
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
New recipe to clean up [suppression.xml files from dependencyCheck](https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd)

## What's your motivation?
Outdated suppressions are often merely forgotten, and can be cleaned up.
The git history will show past suppressions; and the build will fail if still needed
Fixes #24

## Any additional context
- #24 
- https://jeremylong.github.io/DependencyCheck