### PR TITLE
Use `getVisitor` in `ChangeDependency` over `getRecipeList` for reuse

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/RelocatedDependencyCheck.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RelocatedDependencyCheck.java
@@ -130,8 +130,9 @@ public class RelocatedDependencyCheck extends ScanningRecipe<RelocatedDependency
             }
 
             private TreeVisitor<?, ExecutionContext> gradleVisitor() {
-                MethodMatcher dependencyMatcher = new MethodMatcher("DependencyHandlerSpec *(..)");
                 return new GroovyIsoVisitor<ExecutionContext>() {
+                    private final MethodMatcher dependencyMatcher = new MethodMatcher("DependencyHandlerSpec *(..)");
+
                     @Override
                     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
@@ -232,8 +233,9 @@ public class RelocatedDependencyCheck extends ScanningRecipe<RelocatedDependency
             }
 
             private TreeVisitor<?, ExecutionContext> mavenVisitor() {
-                final XPathMatcher dependencyMatcher = new XPathMatcher("//dependencies/dependency");
                 return new MavenIsoVisitor<ExecutionContext>() {
+                    private final XPathMatcher dependencyMatcher = new XPathMatcher("//dependencies/dependency");
+
                     @Override
                     public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
                         tag = super.visitTag(tag, ctx);

--- a/src/main/java/org/openrewrite/java/dependencies/RelocatedDependencyCheck.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RelocatedDependencyCheck.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
-import org.openrewrite.gradle.ChangeDependency;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.StringUtils;
@@ -31,7 +30,6 @@ import org.openrewrite.java.dependencies.table.RelocatedDependencyReport;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.SearchResult;
-import org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
@@ -264,7 +262,7 @@ public class RelocatedDependencyCheck extends ScanningRecipe<RelocatedDependency
                             if (Boolean.TRUE.equals(changeDependencies) && artifactId != null) {
                                 String newGroupId = relocation.getTo().getGroupId();
                                 String newArtifactId = Optional.ofNullable(relocation.getTo().getArtifactId()).orElse(artifactId);
-                                doAfterVisit(new ChangeDependencyGroupIdAndArtifactId(
+                                doAfterVisit(new ChangeDependency(
                                         groupId, artifactId, newGroupId, newArtifactId,
                                         "latest.release", null, null).getVisitor());
                             } else {

--- a/src/test/java/org/openrewrite/java/dependencies/RelocatedDependencyCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RelocatedDependencyCheckTest.java
@@ -29,6 +29,7 @@ import org.openrewrite.test.RewriteTest;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.withToolingApi;
@@ -143,7 +144,7 @@ class RelocatedDependencyCheckTest implements RewriteTest {
                     </dependencies>
                   </project>
                   """.formatted(Pattern.compile("<version>(.*)</version>")
-                  .matcher(actual).results().skip(1).findFirst().orElseThrow().group(1))
+                  .matcher(requireNonNull(actual)).results().skip(1).findFirst().orElseThrow().group(1))
                 )
               )
             );
@@ -324,7 +325,7 @@ class RelocatedDependencyCheckTest implements RewriteTest {
                       implementation "%s"
                   }
                   """.formatted(Pattern.compile("com.mysql:mysql-connector-j:[^\"]+")
-                  .matcher(actual).results().findFirst().orElseThrow().group()))
+                  .matcher(requireNonNull(actual)).results().findFirst().orElseThrow().group()))
               )
             );
         }


### PR DESCRIPTION
## What's your motivation?
Want to use this in `RelocatedDependencyCheck`, but even in this form it's not yet working.

## Any additional context
- https://github.com/openrewrite/rewrite-java-dependencies/pull/63#issuecomment-1902681113