### PR TITLE
`org.openrewrite.gradle.Assertions#withToolingModel` moved to `org.openrewrite.gradle.toolingapi.Assertions`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,13 +34,12 @@ dependencies {
     testRuntimeOnly("org.openrewrite:rewrite-java-17")
     testRuntimeOnly("org.projectlombok:lombok:latest.release")
 
-    implementation("org.openrewrite.gradle.tooling:model:${rewriteVersion}")
-
     implementation("com.google.guava:guava:latest.release")
 
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
+    testImplementation("org.openrewrite.gradle.tooling:model:$rewriteVersion")
     testRuntimeOnly("org.gradle:gradle-tooling-api:latest.release")
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")

--- a/src/test/java/org/openrewrite/java/dependencies/AddDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/AddDependencyTest.java
@@ -26,7 +26,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 

--- a/src/test/java/org/openrewrite/java/dependencies/ChangeDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/ChangeDependencyTest.java
@@ -22,7 +22,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class ChangeDependencyTest implements RewriteTest {

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyListTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyListTest.java
@@ -22,7 +22,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class DependencyListTest implements RewriteTest {

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyResolutionDiagnosticTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyResolutionDiagnosticTest.java
@@ -30,7 +30,7 @@ import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 @SuppressWarnings("GroovyAssignabilityCheck")

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
@@ -24,7 +24,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class DependencyVulnerabilityCheckTest implements RewriteTest {

--- a/src/test/java/org/openrewrite/java/dependencies/RelocatedDependencyCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RelocatedDependencyCheckTest.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class RelocatedDependencyCheckTest implements RewriteTest {

--- a/src/test/java/org/openrewrite/java/dependencies/RemoveDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RemoveDependencyTest.java
@@ -20,7 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class RemoveDependencyTest implements RewriteTest {

--- a/src/test/java/org/openrewrite/java/dependencies/UpgradeDependencyVersionTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/UpgradeDependencyVersionTest.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class UpgradeDependencyVersionTest implements RewriteTest {


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.ChangeMethodTargetToStatic?organizationId=T3BlblJld3JpdGU%3D