### PR TITLE
Added default null for scope whitelist of UpgradeTransitiveDependencyVersion for now

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
@@ -246,7 +246,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                         if (t == t2) {
                             if(Boolean.TRUE.equals(overrideTransitive)) {
                                 t2 = new UpgradeTransitiveDependencyVersion(gaToVb.getKey().getGroupId(), gaToVb.getKey().getArtifactId(),
-                                        gaToVb.getValue().getVersion(), null, because)
+                                        gaToVb.getValue().getVersion(), null, because, null)
                                         .getVisitor()
                                         .visitNonNull(t, ctx);
                                 if (t != t2) {


### PR DESCRIPTION
In order not to block others, I just added the null argument for now while I work on a full fix for the recipe. 