### PR TITLE
Find Nuget dependency vulnerabilities

### DIFF
--- a/.github/workflows/advisories.yml
+++ b/.github/workflows/advisories.yml
@@ -37,11 +37,16 @@ jobs:
       - name: Create commit message
         run: |
           echo "MSG=[Auto] GitHub advisories as of $(date +'%Y-%m-%dT%H%M')" >> $GITHUB_ENV
-      - name: Commit and push to rewrite-java-dependencies
+      - name: Commit and push Maven dependency vulnerabilities to rewrite-java-dependencies
         run: |
           ./gradlew parseGithubAdvisoryDatabase --args="./advisory-database Maven src/main/resources/advisories-maven.csv"
           sort --output=src/main/resources/advisories-maven.csv src/main/resources/advisories-maven.csv
           git diff-index --quiet HEAD src/main/resources/advisories-maven.csv || (git commit --message "${{ env.MSG }}" src/main/resources/advisories-maven.csv && git push origin main)
+      - name: Commit and push Nuget dependency vulnerabilities to rewrite-java-dependencies
+        run: |
+          ./gradlew parseGithubAdvisoryDatabase --args="./advisory-database Nuget src/main/resources/advisories-nuget.csv"
+          sort --output=src/main/resources/advisories-nuget.csv src/main/resources/advisories-nuget.csv
+          git diff-index --quiet HEAD src/main/resources/advisories-nuget.csv || (git commit --message "${{ env.MSG }}" src/main/resources/advisories-nuget.csv && git push origin main)
 
       # Load SSH deploy-key
       - uses: webfactory/ssh-agent@v0.9.0
@@ -49,7 +54,7 @@ jobs:
           ssh-private-key: ${{ secrets.REWRITE_NODEJS_DEPLOY_KEY }}
 
       # Commit and push NPM advisories to rewrite-nodejs
-      - name: Commit and push to rewrite-nodejs
+      - name: Commit and push Npm dependency vulnerabilities to rewrite-nodejs
         run: |
           git clone --depth 1 git@github.com:openrewrite/rewrite-nodejs.git
           ./gradlew parseGithubAdvisoryDatabase --args="./advisory-database NPM rewrite-nodejs/src/main/resources/advisories-npm.csv"

--- a/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
@@ -173,7 +173,6 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                     if (!applicableVulnerabilities.isEmpty()) {
                         for (Vulnerability vulnerability : applicableVulnerabilities) {
                             if (isFixWithPatchVersionUpdateOnly(dependencyVersion, vulnerability)) {
-                                // TODO Pick the highest fix version that is still a patch update, not just the last one
                                 tag = ref.withVersion(vulnerability.getFixedVersion());
                             } else if (Boolean.TRUE.equals(addMarkers)) {
                                 return SearchResult.found(tag,

--- a/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
@@ -146,8 +146,9 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
     private static final Comparator<Version> vc = new StaticVersionComparator();
 
     private boolean isVulnerable(String dependencyVersion, Vulnerability v) {
-        Version resolvedVersion = versionParser.transform(dependencyVersion);
-        return vc.compare(resolvedVersion, versionParser.transform(v.getFixedVersion())) < 0;
+        return vc.compare(
+                versionParser.transform(dependencyVersion),
+                versionParser.transform(v.getFixedVersion())) < 0;
     }
 
     private static final LatestPatch latestPatch = new LatestPatch(null);

--- a/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.dependencies;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.csharp.dependencies.table.VulnerabilityReport;
+import org.openrewrite.csharp.dependencies.trait.PackageReference;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.java.dependencies.Vulnerability;
+import org.openrewrite.java.dependencies.internal.StaticVersionComparator;
+import org.openrewrite.java.dependencies.internal.Version;
+import org.openrewrite.java.dependencies.internal.VersionParser;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.semver.LatestPatch;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.joining;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulnerabilityCheck.Accumulator> {
+    transient VersionParser versionParser = new VersionParser();
+    transient VulnerabilityReport report = new VulnerabilityReport(this);
+
+    @Option(displayName = "Add search markers",
+            description = "Report each vulnerability as search result markers. " +
+                          "When enabled you can see which dependencies are bringing in vulnerable transitives in the diff view. " +
+                          "By default these markers are omitted, making it easier to see version upgrades within the diff.",
+            required = false)
+    @Nullable
+    Boolean addMarkers;
+
+    @Override
+    public String getDisplayName() {
+        return "Find and fix vulnerable Nuget dependencies";
+    }
+
+    @Override
+    public String getDescription() {
+        //language=markdown
+        return "This software composition analysis (SCA) tool detects and upgrades dependencies with publicly disclosed vulnerabilities. " +
+               "This recipe both generates a report of vulnerable dependencies and upgrades to newer versions with fixes. " +
+               "This recipe **only** upgrades to the latest **patch** version.  If a minor or major upgrade is required to reach the fixed version, this recipe will not make any changes. " +
+               "Vulnerability information comes from the [GitHub Security Advisory Database](https://docs.github.com/en/code-security/security-advisories/global-security-advisories/about-the-github-advisory-database), " +
+               "which aggregates vulnerability data from several public databases, including the [National Vulnerability Database](https://nvd.nist.gov/) maintained by the United States government. " +
+               "Dependencies following [Semantic Versioning](https://semver.org/) will see their _patch_ version updated where applicable.";
+    }
+
+    @Value
+    public static class Accumulator {
+        Map<String, List<Vulnerability>> db;
+        Map<NameVersion, Set<Vulnerability>> vulnerabilities;
+
+        @Value
+        static class NameVersion {
+            /**
+             * The name of the package as specified in the package.json.
+             */
+            String name;
+
+            /**
+             * The resolved version actually in use, which may be different from the version specified in the package.json.
+             */
+            String version;
+        }
+    }
+
+    @Override
+    public Accumulator getInitialValue(ExecutionContext ctx) {
+        CsvMapper csvMapper = new CsvMapper();
+        csvMapper.registerModule(new JavaTimeModule());
+        Map<String, List<Vulnerability>> db = new HashMap<>();
+
+        try (InputStream resourceAsStream = DependencyVulnerabilityCheck.class.getResourceAsStream("/advisories-nuget.csv");
+             MappingIterator<Vulnerability> vs = csvMapper.readerWithSchemaFor(Vulnerability.class).readValues(resourceAsStream)) {
+            while (vs.hasNextValue()) {
+                Vulnerability v = vs.nextValue();
+                db.computeIfAbsent(v.getGroupArtifact(), g -> new ArrayList<>()).add(v);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return new Accumulator(db, new HashMap<>());
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
+        return new PackageReference.Matcher().asVisitor((ref, ctx) -> {
+            // Find all vulnerable dependencies and add them to the accumulator
+            for (Vulnerability v : acc.getDb().getOrDefault(ref.getInclude(), Collections.emptyList())) {
+                String resolvedVersion = ref.getVersion() == null ? null : ref.getVersion();
+                acc.getVulnerabilities()
+                        .computeIfAbsent(new Accumulator.NameVersion(ref.getInclude(), resolvedVersion), nv -> new LinkedHashSet<>())
+                        .add(v);
+            }
+            return ref.getTree();
+        });
+    }
+
+    @Override
+    public Collection<SourceFile> generate(Accumulator acc, ExecutionContext ctx) {
+        Comparator<Version> vc = new StaticVersionComparator();
+        LatestPatch latestPatch = new LatestPatch(null);
+        for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> vulnerabilitiesByPackage : acc.getVulnerabilities().entrySet()) {
+            Accumulator.NameVersion nameVersion = vulnerabilitiesByPackage.getKey();
+            Version resolvedVersion = versionParser.transform(nameVersion.getVersion());
+            for (Vulnerability v : vulnerabilitiesByPackage.getValue()) {
+                if (vc.compare(resolvedVersion, versionParser.transform(v.getFixedVersion())) < 0) {
+                    boolean fixWithPatchVersionUpdateOnly = latestPatch.isValid(nameVersion.getVersion(), v.getFixedVersion()) &&
+                                                            latestPatch.compare(nameVersion.getVersion(), nameVersion.getVersion(), v.getFixedVersion()) < 0;
+                    // Insert a row into the report for each vulnerability
+                    report.insertRow(ctx, new VulnerabilityReport.Row(
+                            v.getCve(),
+                            nameVersion.getName(),
+                            nameVersion.getVersion(),
+                            v.getFixedVersion(),
+                            fixWithPatchVersionUpdateOnly,
+                            v.getSummary(),
+                            v.getSeverity().toString(),
+                            0,
+                            v.getCwes()
+                    ));
+                }
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
+        Comparator<Version> vc = new StaticVersionComparator();
+        LatestPatch latestPatch = new LatestPatch(null);
+        return new PackageReference.Matcher().asVisitor((ref, ctx) -> {
+            for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : acc.getVulnerabilities().entrySet()) {
+                String resolvedVersion = entry.getKey().getVersion();
+                for (Vulnerability v : entry.getValue()) {
+                    boolean fixWithPatchVersionUpdateOnly = latestPatch.isValid(resolvedVersion, v.getFixedVersion()) &&
+                                                            latestPatch.compare(resolvedVersion, resolvedVersion, v.getFixedVersion()) < 0;
+                    if (fixWithPatchVersionUpdateOnly) {
+                        // TODO update the dependency version
+                    }
+                }
+            }
+
+            if (!Boolean.TRUE.equals(addMarkers)) {
+                return ref.getTree();
+            }
+
+            String name = ref.getInclude();
+            for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : acc.getVulnerabilities().entrySet()) {
+                Accumulator.NameVersion nameVersion = entry.getKey();
+                if (nameVersion.getName().equals(name)) {
+                    Version resolvedVersion = versionParser.transform(nameVersion.getVersion());
+                    List<Vulnerability> applicableVulnerabilities = entry.getValue().stream()
+                            .filter(v -> StringUtils.isBlank(v.getFixedVersion()) ||
+                                         vc.compare(resolvedVersion, versionParser.transform(v.getFixedVersion())) < 0)
+                            .collect(Collectors.toList());
+                    if (!applicableVulnerabilities.isEmpty()) {
+                        return SearchResult.found(ref.getTree(),
+                                "This dependency has the following vulnerabilities:\n" +
+                                applicableVulnerabilities.stream()
+                                        .map(v -> String.format("%s (%s severity%s) - %s",
+                                                v.getCve(),
+                                                v.getSeverity(),
+                                                StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion(),
+                                                v.getSummary()))
+                                        .collect(joining("\n")));
+                    }
+                }
+            }
+
+            return ref.getTree();
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
@@ -39,9 +39,10 @@ import org.openrewrite.xml.tree.Xml;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
-import java.util.stream.Collectors;
 
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.partitioningBy;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -162,29 +163,35 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
         return new PackageReference.Matcher().asVisitor((ref, ctx) -> {
             Xml.Tag tag = ref.getTree();
 
+            // Partition vulnerabilities into those that can be fixed with a patch version update and those that can't
             String dependencyVersion = ref.getVersion();
-            List<Vulnerability> vulnerabilities = acc.vulnerabilities
-                    .getOrDefault(new Accumulator.NameVersion(ref.getInclude(), ref.getVersion()), Collections.emptySet())
+            Map<Boolean, List<Vulnerability>> vulnerabilities = acc.vulnerabilities
+                    .getOrDefault(new Accumulator.NameVersion(ref.getInclude(), ref.getVersion()), emptySet())
                     .stream()
                     .filter(v -> StringUtils.isBlank(v.getFixedVersion()) || isVulnerable(dependencyVersion, v))
-                    .collect(Collectors.toList());
-            if (!vulnerabilities.isEmpty()) {
-                for (Vulnerability vulnerability : vulnerabilities) {
-                    if (isFixWithPatchVersionUpdateOnly(dependencyVersion, vulnerability)) {
-                        tag = ref.withVersion(vulnerability.getFixedVersion());
-                    } else if (Boolean.TRUE.equals(addMarkers)) {
-                        // TODO Do not loop over all vulnerabilities a second time
-                        return SearchResult.found(tag,
-                                "This dependency has the following vulnerabilities:\n" +
-                                vulnerabilities.stream()
-                                        .map(v -> String.format("%s (%s severity%s) - %s",
-                                                v.getCve(),
-                                                v.getSeverity(),
-                                                StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion(),
-                                                v.getSummary()))
-                                        .collect(joining("\n")));
-                    }
-                }
+                    .collect(partitioningBy(v -> isFixWithPatchVersionUpdateOnly(dependencyVersion, v)));
+
+            // Bump to highest fixed patch version
+            String highestFixedPatchVersion = vulnerabilities.get(true).stream()
+                    .max(Comparator.comparing(v -> versionParser.transform(v.getFixedVersion()), vc))
+                    .map(Vulnerability::getFixedVersion)
+                    .orElse(null);
+            if (highestFixedPatchVersion != null) {
+                tag = ref.withVersion(highestFixedPatchVersion);
+            }
+
+            // Add marker of vulnerabilities not patched
+            List<Vulnerability> remainingVulnerabilities = vulnerabilities.get(false);
+            if (Boolean.TRUE.equals(addMarkers) && !remainingVulnerabilities.isEmpty()) {
+                tag = SearchResult.found(tag,
+                        "This dependency has the following vulnerabilities:\n" +
+                        remainingVulnerabilities.stream()
+                                .map(v -> String.format("%s (%s severity%s) - %s",
+                                        v.getCve(),
+                                        v.getSeverity(),
+                                        StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion(),
+                                        v.getSummary()))
+                                .collect(joining("\n")));
             }
 
             return tag;

--- a/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
@@ -159,7 +159,6 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
-        Comparator<Version> vc = new StaticVersionComparator();
         return new PackageReference.Matcher().asVisitor((ref, ctx) -> {
             Xml.Tag tag = ref.getTree();
 

--- a/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
@@ -162,30 +162,27 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
         return new PackageReference.Matcher().asVisitor((ref, ctx) -> {
             Xml.Tag tag = ref.getTree();
 
-            String name = ref.getInclude();
-            for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : acc.vulnerabilities.entrySet()) {
-                Accumulator.NameVersion nameVersion = entry.getKey();
-                if (nameVersion.getName().equals(name)) {
-                    String dependencyVersion = nameVersion.getVersion();
-                    List<Vulnerability> applicableVulnerabilities = entry.getValue().stream()
-                            .filter(v -> StringUtils.isBlank(v.getFixedVersion()) || isVulnerable(dependencyVersion, v))
-                            .collect(Collectors.toList());
-                    if (!applicableVulnerabilities.isEmpty()) {
-                        for (Vulnerability vulnerability : applicableVulnerabilities) {
-                            if (isFixWithPatchVersionUpdateOnly(dependencyVersion, vulnerability)) {
-                                tag = ref.withVersion(vulnerability.getFixedVersion());
-                            } else if (Boolean.TRUE.equals(addMarkers)) {
-                                return SearchResult.found(tag,
-                                        "This dependency has the following vulnerabilities:\n" +
-                                        applicableVulnerabilities.stream()
-                                                .map(v -> String.format("%s (%s severity%s) - %s",
-                                                        v.getCve(),
-                                                        v.getSeverity(),
-                                                        StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion(),
-                                                        v.getSummary()))
-                                                .collect(joining("\n")));
-                            }
-                        }
+            String dependencyVersion = ref.getVersion();
+            List<Vulnerability> vulnerabilities = acc.vulnerabilities
+                    .getOrDefault(new Accumulator.NameVersion(ref.getInclude(), ref.getVersion()), Collections.emptySet())
+                    .stream()
+                    .filter(v -> StringUtils.isBlank(v.getFixedVersion()) || isVulnerable(dependencyVersion, v))
+                    .collect(Collectors.toList());
+            if (!vulnerabilities.isEmpty()) {
+                for (Vulnerability vulnerability : vulnerabilities) {
+                    if (isFixWithPatchVersionUpdateOnly(dependencyVersion, vulnerability)) {
+                        tag = ref.withVersion(vulnerability.getFixedVersion());
+                    } else if (Boolean.TRUE.equals(addMarkers)) {
+                        // TODO Do not loop over all vulnerabilities a second time
+                        return SearchResult.found(tag,
+                                "This dependency has the following vulnerabilities:\n" +
+                                vulnerabilities.stream()
+                                        .map(v -> String.format("%s (%s severity%s) - %s",
+                                                v.getCve(),
+                                                v.getSeverity(),
+                                                StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion(),
+                                                v.getSummary()))
+                                        .collect(joining("\n")));
                     }
                 }
             }

--- a/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
@@ -31,6 +31,7 @@ import org.openrewrite.java.dependencies.internal.Version;
 import org.openrewrite.java.dependencies.internal.VersionParser;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.semver.LatestPatch;
+import org.openrewrite.xml.tree.Xml;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -155,19 +156,22 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
         Comparator<Version> vc = new StaticVersionComparator();
         LatestPatch latestPatch = new LatestPatch(null);
         return new PackageReference.Matcher().asVisitor((ref, ctx) -> {
+            Xml.Tag tag = ref.getTree();
+
             for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : acc.getVulnerabilities().entrySet()) {
                 String resolvedVersion = entry.getKey().getVersion();
                 for (Vulnerability v : entry.getValue()) {
                     boolean fixWithPatchVersionUpdateOnly = latestPatch.isValid(resolvedVersion, v.getFixedVersion()) &&
                                                             latestPatch.compare(resolvedVersion, resolvedVersion, v.getFixedVersion()) < 0;
                     if (fixWithPatchVersionUpdateOnly) {
-                        // TODO update the dependency version
+                        // TODO Only set version if higher than previously patched
+                        tag = ref.withVersion(v.getFixedVersion());
                     }
                 }
             }
 
             if (!Boolean.TRUE.equals(addMarkers)) {
-                return ref.getTree();
+                return tag;
             }
 
             String name = ref.getInclude();
@@ -180,7 +184,8 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                                          vc.compare(resolvedVersion, versionParser.transform(v.getFixedVersion())) < 0)
                             .collect(Collectors.toList());
                     if (!applicableVulnerabilities.isEmpty()) {
-                        return SearchResult.found(ref.getTree(),
+                        // TODO Omit vulnerabilities already patched above
+                        return SearchResult.found(tag,
                                 "This dependency has the following vulnerabilities:\n" +
                                 applicableVulnerabilities.stream()
                                         .map(v -> String.format("%s (%s severity%s) - %s",
@@ -193,7 +198,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                 }
             }
 
-            return ref.getTree();
+            return tag;
         });
     }
 }

--- a/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
@@ -158,42 +158,35 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
         return new PackageReference.Matcher().asVisitor((ref, ctx) -> {
             Xml.Tag tag = ref.getTree();
 
-            for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : acc.getVulnerabilities().entrySet()) {
-                String resolvedVersion = entry.getKey().getVersion();
-                for (Vulnerability v : entry.getValue()) {
-                    boolean fixWithPatchVersionUpdateOnly = latestPatch.isValid(resolvedVersion, v.getFixedVersion()) &&
-                                                            latestPatch.compare(resolvedVersion, resolvedVersion, v.getFixedVersion()) < 0;
-                    if (fixWithPatchVersionUpdateOnly) {
-                        // TODO Only set version if higher than previously patched
-                        tag = ref.withVersion(v.getFixedVersion());
-                    }
-                }
-            }
-
-            if (!Boolean.TRUE.equals(addMarkers)) {
-                return tag;
-            }
-
             String name = ref.getInclude();
             for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : acc.getVulnerabilities().entrySet()) {
                 Accumulator.NameVersion nameVersion = entry.getKey();
                 if (nameVersion.getName().equals(name)) {
-                    Version resolvedVersion = versionParser.transform(nameVersion.getVersion());
+                    String rawVersion = nameVersion.getVersion();
+                    Version resolvedVersion = versionParser.transform(rawVersion);
                     List<Vulnerability> applicableVulnerabilities = entry.getValue().stream()
                             .filter(v -> StringUtils.isBlank(v.getFixedVersion()) ||
                                          vc.compare(resolvedVersion, versionParser.transform(v.getFixedVersion())) < 0)
                             .collect(Collectors.toList());
+
                     if (!applicableVulnerabilities.isEmpty()) {
-                        // TODO Omit vulnerabilities already patched above
-                        return SearchResult.found(tag,
-                                "This dependency has the following vulnerabilities:\n" +
-                                applicableVulnerabilities.stream()
-                                        .map(v -> String.format("%s (%s severity%s) - %s",
-                                                v.getCve(),
-                                                v.getSeverity(),
-                                                StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion(),
-                                                v.getSummary()))
-                                        .collect(joining("\n")));
+                        for (Vulnerability vulnerability : entry.getValue()) {
+                            boolean fixWithPatchVersionUpdateOnly = latestPatch.isValid(rawVersion, vulnerability.getFixedVersion()) &&
+                                                                    latestPatch.compare(rawVersion, rawVersion, vulnerability.getFixedVersion()) < 0;
+                            if (fixWithPatchVersionUpdateOnly) {
+                                tag = ref.withVersion(vulnerability.getFixedVersion());
+                            } else if (Boolean.TRUE.equals(addMarkers)) {
+                                return SearchResult.found(tag,
+                                        "This dependency has the following vulnerabilities:\n" +
+                                        applicableVulnerabilities.stream()
+                                                .map(v -> String.format("%s (%s severity%s) - %s",
+                                                        v.getCve(),
+                                                        v.getSeverity(),
+                                                        StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion(),
+                                                        v.getSummary()))
+                                                .collect(joining("\n")));
+                            }
+                        }
                     }
                 }
             }

--- a/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheck.java
@@ -21,7 +21,10 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.csharp.dependencies.table.VulnerabilityReport;
 import org.openrewrite.csharp.dependencies.trait.PackageReference;
 import org.openrewrite.internal.StringUtils;
@@ -111,35 +114,22 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
         return new PackageReference.Matcher().asVisitor((ref, ctx) -> {
-            // Find all vulnerable dependencies and add them to the accumulator
-            for (Vulnerability v : acc.getDb().getOrDefault(ref.getInclude(), Collections.emptyList())) {
-                String resolvedVersion = ref.getVersion() == null ? null : ref.getVersion();
-                acc.getVulnerabilities()
-                        .computeIfAbsent(new Accumulator.NameVersion(ref.getInclude(), resolvedVersion), nv -> new LinkedHashSet<>())
-                        .add(v);
-            }
-            return ref.getTree();
-        });
-    }
+            String dependencyName = ref.getInclude();
+            for (Vulnerability v : acc.db.getOrDefault(dependencyName, Collections.emptyList())) {
+                String dependencyVersion = ref.getVersion();
+                if (isVulnerable(dependencyVersion, v)) {
+                    // Add all vulnerable dependencies to the accumulator
+                    acc.vulnerabilities
+                            .computeIfAbsent(new Accumulator.NameVersion(dependencyName, dependencyVersion), nv -> new LinkedHashSet<>())
+                            .add(v);
 
-    @Override
-    public Collection<SourceFile> generate(Accumulator acc, ExecutionContext ctx) {
-        Comparator<Version> vc = new StaticVersionComparator();
-        LatestPatch latestPatch = new LatestPatch(null);
-        for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> vulnerabilitiesByPackage : acc.getVulnerabilities().entrySet()) {
-            Accumulator.NameVersion nameVersion = vulnerabilitiesByPackage.getKey();
-            Version resolvedVersion = versionParser.transform(nameVersion.getVersion());
-            for (Vulnerability v : vulnerabilitiesByPackage.getValue()) {
-                if (vc.compare(resolvedVersion, versionParser.transform(v.getFixedVersion())) < 0) {
-                    boolean fixWithPatchVersionUpdateOnly = latestPatch.isValid(nameVersion.getVersion(), v.getFixedVersion()) &&
-                                                            latestPatch.compare(nameVersion.getVersion(), nameVersion.getVersion(), v.getFixedVersion()) < 0;
                     // Insert a row into the report for each vulnerability
                     report.insertRow(ctx, new VulnerabilityReport.Row(
                             v.getCve(),
-                            nameVersion.getName(),
-                            nameVersion.getVersion(),
+                            dependencyName,
+                            dependencyVersion,
                             v.getFixedVersion(),
-                            fixWithPatchVersionUpdateOnly,
+                            isFixWithPatchVersionUpdateOnly(dependencyVersion, v),
                             v.getSummary(),
                             v.getSeverity().toString(),
                             0,
@@ -147,33 +137,44 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                     ));
                 }
             }
-        }
-        return Collections.emptyList();
+            return ref.getTree();
+        });
+    }
+
+
+    private static final Comparator<Version> vc = new StaticVersionComparator();
+
+    private boolean isVulnerable(String dependencyVersion, Vulnerability v) {
+        Version resolvedVersion = versionParser.transform(dependencyVersion);
+        return vc.compare(resolvedVersion, versionParser.transform(v.getFixedVersion())) < 0;
+    }
+
+    private static final LatestPatch latestPatch = new LatestPatch(null);
+
+    private static boolean isFixWithPatchVersionUpdateOnly(String dependencyVersion, Vulnerability v) {
+        return !StringUtils.isBlank(v.getFixedVersion()) &&
+               latestPatch.isValid(dependencyVersion, v.getFixedVersion()) &&
+               latestPatch.compare(dependencyVersion, dependencyVersion, v.getFixedVersion()) < 0;
     }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
         Comparator<Version> vc = new StaticVersionComparator();
-        LatestPatch latestPatch = new LatestPatch(null);
         return new PackageReference.Matcher().asVisitor((ref, ctx) -> {
             Xml.Tag tag = ref.getTree();
 
             String name = ref.getInclude();
-            for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : acc.getVulnerabilities().entrySet()) {
+            for (Map.Entry<Accumulator.NameVersion, Set<Vulnerability>> entry : acc.vulnerabilities.entrySet()) {
                 Accumulator.NameVersion nameVersion = entry.getKey();
                 if (nameVersion.getName().equals(name)) {
-                    String rawVersion = nameVersion.getVersion();
-                    Version resolvedVersion = versionParser.transform(rawVersion);
+                    String dependencyVersion = nameVersion.getVersion();
                     List<Vulnerability> applicableVulnerabilities = entry.getValue().stream()
-                            .filter(v -> StringUtils.isBlank(v.getFixedVersion()) ||
-                                         vc.compare(resolvedVersion, versionParser.transform(v.getFixedVersion())) < 0)
+                            .filter(v -> StringUtils.isBlank(v.getFixedVersion()) || isVulnerable(dependencyVersion, v))
                             .collect(Collectors.toList());
-
                     if (!applicableVulnerabilities.isEmpty()) {
-                        for (Vulnerability vulnerability : entry.getValue()) {
-                            boolean fixWithPatchVersionUpdateOnly = latestPatch.isValid(rawVersion, vulnerability.getFixedVersion()) &&
-                                                                    latestPatch.compare(rawVersion, rawVersion, vulnerability.getFixedVersion()) < 0;
-                            if (fixWithPatchVersionUpdateOnly) {
+                        for (Vulnerability vulnerability : applicableVulnerabilities) {
+                            if (isFixWithPatchVersionUpdateOnly(dependencyVersion, vulnerability)) {
+                                // TODO Pick the highest fix version that is still a patch update, not just the last one
                                 tag = ref.withVersion(vulnerability.getFixedVersion());
                             } else if (Boolean.TRUE.equals(addMarkers)) {
                                 return SearchResult.found(tag,

--- a/src/main/java/org/openrewrite/csharp/dependencies/table/VulnerabilityReport.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/table/VulnerabilityReport.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.dependencies.table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+@JsonIgnoreType
+public class VulnerabilityReport extends DataTable<VulnerabilityReport.Row> {
+
+    public VulnerabilityReport(Recipe recipe) {
+        super(recipe,
+                "Vulnerability report",
+                "A vulnerability report that includes detailed information about the affected artifact and the corresponding CVEs.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "CVE",
+                description = "The CVE number.")
+        String cve;
+
+        @Column(displayName = "Package name",
+                description = "The package name.")
+        String packageName;
+
+        @Column(displayName = "Version",
+                description = "The resolved version.")
+        String version;
+
+        @Column(displayName = "Fixed in version",
+                description = "The minimum version that is no longer vulnerable.")
+        String fixedVersion;
+
+        @Column(displayName = "Fixable with version update only",
+                //language=markdown
+                description = "Whether the vulnerability is likely to be fixed by increasing the dependency version only, " +
+                              "with no code modifications required. This is a heuristic which assumes that the dependency " +
+                              "is accurately versioned according to [semver](https://semver.org/).")
+        boolean fixWithVersionUpdateOnly;
+
+        @Column(displayName = "Summary",
+                description = "The summary of the CVE.")
+        String summary;
+
+        @Column(displayName = "Base score",
+                description = "The calculated base score.")
+        String severity;
+
+        @Column(displayName = "Depth",
+                description = "Zero for direct dependencies.")
+        Integer depth;
+
+        @Column(displayName = "CWEs",
+                description = "Common Weakness Enumeration (CWE) identifiers; semicolon separated.")
+        String CWEs;
+    }
+}

--- a/src/main/java/org/openrewrite/csharp/dependencies/table/package-info.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/table/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package org.openrewrite.csharp.dependencies.table;
+
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/main/java/org/openrewrite/csharp/dependencies/trait/PackageReference.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/trait/PackageReference.java
@@ -16,7 +16,8 @@
 package org.openrewrite.csharp.dependencies.trait;
 
 import lombok.Value;
-import org.openrewrite.*;
+import org.openrewrite.Cursor;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.trait.SimpleTraitMatcher;
 import org.openrewrite.trait.Trait;
 import org.openrewrite.xml.ChangeTagAttribute;

--- a/src/main/java/org/openrewrite/csharp/dependencies/trait/PackageReference.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/trait/PackageReference.java
@@ -16,14 +16,16 @@
 package org.openrewrite.csharp.dependencies.trait;
 
 import lombok.Value;
-import org.openrewrite.Cursor;
+import org.openrewrite.*;
 import org.openrewrite.trait.SimpleTraitMatcher;
 import org.openrewrite.trait.Trait;
+import org.openrewrite.xml.ChangeTagAttribute;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.toMap;
 
@@ -34,6 +36,18 @@ public class PackageReference implements Trait<Xml.Tag> {
 
     String include;
     String version;
+
+    public Xml.Tag withVersion(String newVersion) {
+        Xml.Tag tag = getTree();
+        if (!Objects.equals(this.version, newVersion)) {
+            InMemoryExecutionContext ctx = new InMemoryExecutionContext();
+            tag = (Xml.Tag) new ChangeTagAttribute("//PackageReference", "Version", newVersion, this.version, null)
+                    .getVisitor().visitNonNull(tag, ctx);
+            tag = (Xml.Tag) new ChangeTagAttribute("/packages/package", "version", newVersion, this.version, null)
+                    .getVisitor().visitNonNull(tag, ctx);
+        }
+        return tag;
+    }
 
     public static class Matcher extends SimpleTraitMatcher<PackageReference> {
         XPathMatcher packageReference = new XPathMatcher("//PackageReference");

--- a/src/main/java/org/openrewrite/java/dependencies/Vulnerability.java
+++ b/src/main/java/org/openrewrite/java/dependencies/Vulnerability.java
@@ -31,6 +31,7 @@ public class Vulnerability {
     ZonedDateTime publishedAt;
     String summary;
     String groupArtifact;
+    @EqualsAndHashCode.Include
     String introducedVersion;
     String fixedVersion;
     Severity severity;

--- a/src/main/resources/advisories-nuget.csv
+++ b/src/main/resources/advisories-nuget.csv
@@ -1,0 +1,2274 @@
+CVE-2006-0743,2022-05-01T06:42:27Z,"Apache log4net format string vulnerability causes DoS",log4net,0,1.2.10,MODERATE,CWE-134
+CVE-2007-0660,2022-05-01T17:46:11Z,"DotNetNuke Vulnerable to XSS in Pass-Through Values",DotNetNuke.Core,0,03.02.01,MODERATE,CWE-79
+CVE-2008-6540,2022-05-14T02:38:47Z,"DotNetNuke Default Machine Key Exposure",DotNetNuke.Core,0,4.8.2,MODERATE,CWE-453
+CVE-2009-4665,2022-05-02T03:56:59Z,"CuteSoft CuteEditor Path Traversal vulnerability",CuteEditor,0,6.6,MODERATE,CWE-22
+CVE-2010-1459,2022-05-02T06:22:59Z,"Mono ASP.NET View State Cross-Site Scripting (XSS) vulnerability",mono,0,2.6.4,MODERATE,CWE-79
+CVE-2010-5312,2017-10-24T18:33:38Z,"Cross-site Scripting in jquery-ui",jQuery.UI.Combined,1.7.0,1.10.0,MODERATE,CWE-79
+CVE-2011-4969,2022-05-14T01:09:51Z,"jQuery vulnerable to Cross-Site Scripting (XSS)",jQuery,0,1.6.3,MODERATE,CWE-79
+CVE-2012-6662,2017-10-24T18:33:37Z,"jquery-ui Tooltip widget vulnerable to XSS",jQuery.UI.Combined,0,1.10.0,MODERATE,CWE-79
+CVE-2012-6708,2020-09-01T16:41:46Z,"Cross-Site Scripting in jquery",jQuery,0,1.9.0,MODERATE,CWE-64;CWE-79
+CVE-2013-4649,2022-05-17T01:33:02Z,"DotNetNuke (DNN) Cross-site scripting (XSS) vulnerability via the __dnnVariable parameter",DotNetNuke.Core,0,6.2.9,MODERATE,CWE-79
+CVE-2013-4649,2022-05-17T01:33:02Z,"DotNetNuke (DNN) Cross-site scripting (XSS) vulnerability via the __dnnVariable parameter",DotNetNuke.Core,7.0,7.1.1,MODERATE,CWE-79
+CVE-2013-7335,2022-05-17T04:49:44Z,"DotNetNuke (DNN) Open redirect vulnerability ",DotNetNuke.Core,0,6.2.9,MODERATE,CWE-20;CWE-601
+CVE-2013-7335,2022-05-17T04:49:44Z,"DotNetNuke (DNN) Open redirect vulnerability ",DotNetNuke.Core,7.0,7.1.1,MODERATE,CWE-20;CWE-601
+CVE-2014-4172,2022-05-17T19:57:18Z,"Jasig Java CAS Client, .NET CAS Client, and phpCAS contain URL parameter injection vulnerability",DotNetCasClient,0,1.0.2,CRITICAL,CWE-74
+CVE-2015-1566,2018-10-16T19:33:25Z,"Moderate severity vulnerability that affects DotNetNuke.Core",DotNetNuke.Core,0,7.4.0,MODERATE,CWE-79
+CVE-2015-2794,2018-10-16T19:33:42Z,"The installation wizard in DotNetNuke (DNN) allows privilege escalation",DotNetNuke.Core,0,7.4.1,CRITICAL,
+CVE-2015-5237,2022-05-13T01:06:54Z,"protobuf susceptible to buffer overflow",Google.Protobuf,0,3.4.0,HIGH,CWE-787
+CVE-2015-8813,2022-05-17T02:56:23Z,"Umbraco CMS vulnerable to CSRF",Umbraco.CMS,0,7.4.0,HIGH,CWE-918
+CVE-2015-8814,2022-05-17T02:56:23Z,"Umbraco CMS vulnerable to CSRF",Umbraco.CMS,0,7.4.0,HIGH,CWE-352
+CVE-2015-9251,2018-01-22T13:32:06Z,"Cross-Site Scripting (XSS) in jquery",jQuery,0,1.12.2,MODERATE,CWE-79
+CVE-2015-9251,2018-01-22T13:32:06Z,"Cross-Site Scripting (XSS) in jquery",jQuery,1.12.3,3.0.0,MODERATE,CWE-79
+CVE-2016-0024,2022-05-14T02:26:20Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.0,HIGH,CWE-119
+CVE-2016-0186,2022-05-14T02:25:02Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.0.0,HIGH,CWE-119
+CVE-2016-0191,2022-05-14T02:24:57Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.0.0,HIGH,CWE-119
+CVE-2016-0193,2022-05-14T02:24:57Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.0.0,HIGH,CWE-119
+CVE-2016-10707,2018-01-22T13:32:42Z,"Denial of Service in jquery",jQuery,3.0.0-rc.1,3.0.0,HIGH,CWE-400;CWE-674
+CVE-2016-10735,2019-01-17T13:57:27Z,"Bootstrap Cross-site Scripting vulnerability",bootstrap,2.0.4,3.4.0,MODERATE,CWE-79
+CVE-2016-10735,2019-01-17T13:57:27Z,"Bootstrap Cross-site Scripting vulnerability",bootstrap,4.0.0-beta,4.0.0-beta.2,MODERATE,CWE-79
+CVE-2016-10735,2019-01-17T13:57:27Z,"Bootstrap Cross-site Scripting vulnerability",bootstrap.sass,4.0.0-beta,4.0.0-beta.2,MODERATE,CWE-79
+CVE-2016-3199,2022-05-14T02:24:35Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.0.0,HIGH,CWE-119
+CVE-2016-3202,2022-05-14T02:24:35Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.0.0,HIGH,CWE-119
+CVE-2016-3214,2022-05-14T02:24:33Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.3.0,HIGH,CWE-119
+CVE-2016-3248,2022-05-14T02:24:16Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,,HIGH,CWE-119
+CVE-2016-3259,2022-05-14T02:24:15Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.0.0,HIGH,CWE-119
+CVE-2016-3260,2022-05-14T02:24:15Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.0.0,HIGH,CWE-119
+CVE-2016-3265,2022-05-14T02:24:13Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.0.0,HIGH,CWE-119
+CVE-2016-3269,2022-05-14T02:24:13Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.0.0,HIGH,CWE-119
+CVE-2016-3296,2022-05-14T02:23:44Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,,HIGH,CWE-119
+CVE-2016-3350,2022-05-14T02:23:18Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.1,HIGH,CWE-119
+CVE-2016-3377,2022-05-14T02:23:14Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.1,HIGH,CWE-119
+CVE-2016-3382,2022-05-14T02:23:12Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.1,HIGH,CWE-119
+CVE-2016-3386,2022-05-14T02:23:11Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.1,HIGH,CWE-119
+CVE-2016-3389,2022-05-14T02:23:11Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.1,HIGH,CWE-119
+CVE-2016-3390,2022-05-14T02:23:11Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.1,HIGH,CWE-119
+CVE-2016-7103,2017-10-24T18:33:35Z,"jQuery-UI vulnerable to Cross-site Scripting in dialog closeText",jQuery.UI.Combined,0,1.12.0,MODERATE,CWE-79
+CVE-2016-7119,2018-10-16T19:34:10Z,"Cross-site scripting (XSS) vulnerability in the user-profile biography section in DotNetNuke (DNN)",DotNetNuke.Core,0,8.0.1,MODERATE,CWE-79
+CVE-2016-7189,2022-05-14T02:22:46Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.1,HIGH,CWE-119
+CVE-2016-7190,2022-05-14T02:22:45Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,,HIGH,CWE-119
+CVE-2016-7194,2022-05-14T02:22:45Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,,HIGH,CWE-119
+CVE-2016-7200,2022-05-14T02:22:42Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.2,HIGH,CWE-119;CWE-787
+CVE-2016-7201,2022-05-14T02:22:42Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.2,HIGH,CWE-119;CWE-843
+CVE-2016-7202,2022-05-14T02:22:42Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.2,HIGH,CWE-119
+CVE-2016-7203,2022-05-14T02:22:42Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.2,HIGH,CWE-119
+CVE-2016-7208,2022-05-14T02:22:41Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.2,HIGH,CWE-119
+CVE-2016-7240,2022-05-14T02:22:18Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.2,HIGH,CWE-119
+CVE-2016-7242,2022-05-14T02:22:18Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.2,HIGH,CWE-119
+CVE-2016-7243,2022-05-14T02:22:17Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.2.2,HIGH,CWE-119
+CVE-2017-0208,2022-05-17T02:32:54Z,"ChakraCore information disclosure vulnerability",Microsoft.ChakraCore,0,1.4.3,MODERATE,CWE-200
+CVE-2017-0223,2022-05-17T02:35:05Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.4.4,CRITICAL,CWE-119
+CVE-2017-0224,2022-05-17T02:44:22Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.4.4,HIGH,CWE-119
+CVE-2017-0234,2022-05-17T02:35:00Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.4.4,HIGH,CWE-119
+CVE-2017-0235,2022-05-17T02:44:21Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.4.4,HIGH,CWE-119
+CVE-2017-0236,2022-05-17T02:34:59Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.4.4,HIGH,CWE-119
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests",Microsoft.AspNetCore.Mvc,1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests",Microsoft.AspNetCore.Mvc,1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Abstractions",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Abstractions",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.ApiExplorer",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.ApiExplorer",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Core",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Core",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Cors",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Cors",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.DataAnnotations",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.DataAnnotations",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Formatters.Json",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Formatters.Json",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Formatters.Xml",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Formatters.Xml",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Localization",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Localization",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Razor",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Razor",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Razor.Host",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.Razor.Host",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.TagHelpers",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.TagHelpers",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.ViewFeatures",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.ViewFeatures",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.WebApiCompatShim",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","Microsoft.AspNetCore.Mvc.WebApiCompatShim",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests",System.Net.Http,4.1.1,4.1.2,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests",System.Net.Http,4.3.1,4.3.2,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","System.Net.Http.WinHttpHandler",4.0.0,4.0.1,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","System.Net.Http.WinHttpHandler",4.3.0,4.5.4,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests",System.Net.Security,4.0.0,4.0.1,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests",System.Net.Security,4.3.0,4.3.1,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","System.Net.WebSockets.Client",4.0.0,4.0.1,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","System.Net.WebSockets.Client",4.3.0,4.3.1,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","System.Text.Encodings.Web",4.0.0,4.0.1,HIGH,CWE-20
+CVE-2017-0247,2018-10-16T19:58:05Z,"ASP.NET Core fails to properly validate web requests","System.Text.Encodings.Web",4.3.0,4.3.1,HIGH,CWE-20
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core",Microsoft.AspNetCore.Mvc,1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core",Microsoft.AspNetCore.Mvc,1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Abstractions",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Abstractions",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.ApiExplorer",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.ApiExplorer",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Core",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Core",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Cors",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Cors",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.DataAnnotations",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.DataAnnotations",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Formatters.Json",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Formatters.Json",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Formatters.Xml",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Formatters.Xml",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Localization",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Localization",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Razor",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Razor",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Razor.Host",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.Razor.Host",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.TagHelpers",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.TagHelpers",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.ViewFeatures",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.ViewFeatures",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.WebApiCompatShim",1.0.0,1.0.4,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","Microsoft.AspNetCore.Mvc.WebApiCompatShim",1.1.0,1.1.3,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core",System.Net.Http,4.1.1,4.1.2,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core",System.Net.Http,4.3.1,4.3.2,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","System.Net.Http.WinHttpHandler",4.0.0,4.0.1,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","System.Net.Http.WinHttpHandler",4.3.0,4.3.1,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core",System.Net.Security,4.0.0,4.0.1,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core",System.Net.Security,4.3.0,4.3.1,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","System.Net.WebSockets.Client",4.0.0,4.0.1,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","System.Net.WebSockets.Client",4.3.0,4.3.1,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","System.Text.Encodings.Web",4.0.0,4.0.1,MODERATE,CWE-295
+CVE-2017-0248,2018-10-16T19:58:52Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core","System.Text.Encodings.Web",4.3.0,4.3.1,MODERATE,CWE-295
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc",DisCatSharp,0,,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc",Microsoft.AspNetCore.Mvc,1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc",Microsoft.AspNetCore.Mvc,1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Abstractions",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Abstractions",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.ApiExplorer",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.ApiExplorer",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Core",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Core",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Cors",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Cors",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.DataAnnotations",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.DataAnnotations",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Formatters.Json",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Formatters.Json",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Formatters.Xml",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Formatters.Xml",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Localization",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Localization",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Razor",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Razor",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Razor.Host",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Razor.Host",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.TagHelpers",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.TagHelpers",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.ViewFeatures",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.ViewFeatures",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.WebApiCompatShim",1.0.0,1.0.4,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.WebApiCompatShim",1.1.0,1.1.3,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc",System.Net.Http,4.1.1,4.1.2,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc",System.Net.Http,4.3.1,4.3.2,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Net.Http.WinHttpHandler",4.0.0,4.0.1,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Net.Http.WinHttpHandler",4.3.0,4.3.1,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc",System.Net.Security,4.0.0,4.0.1,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc",System.Net.Security,4.3.0,4.3.1,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Net.WebSockets.Client",4.0.0,4.0.1,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Net.WebSockets.Client",4.3.0,4.3.1,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Text.Encodings.Web",4.0.0,4.0.1,HIGH,CWE-20
+CVE-2017-0249,2018-10-16T19:57:38Z,"High severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Text.Encodings.Web",4.3.0,4.3.1,HIGH,CWE-20
+CVE-2017-0252,2022-05-17T02:44:02Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.4.4,CRITICAL,CWE-119
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc",Microsoft.AspNetCore.Mvc,1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc",Microsoft.AspNetCore.Mvc,1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Abstractions",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Abstractions",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.ApiExplorer",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.ApiExplorer",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Core",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Core",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Cors",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Cors",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.DataAnnotations",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.DataAnnotations",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Formatters.Json",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Formatters.Json",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Formatters.Xml",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Formatters.Xml",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Localization",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Localization",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Razor",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Razor",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Razor.Host",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.Razor.Host",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.TagHelpers",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.TagHelpers",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.ViewFeatures",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.ViewFeatures",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.WebApiCompatShim",1.0.0,1.0.4,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","Microsoft.AspNetCore.Mvc.WebApiCompatShim",1.1.0,1.1.3,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc",System.Net.Http,4.1.1,4.1.2,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc",System.Net.Http,4.3.1,4.3.2,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Net.Http.WinHttpHandler",4.0.0,4.0.1,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Net.Http.WinHttpHandler",4.3.0,4.3.1,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc",System.Net.Security,4.0.0,4.0.1,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc",System.Net.Security,4.3.0,4.3.1,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Net.WebSockets.Client",4.0.0,4.0.1,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Net.WebSockets.Client",4.3.0,4.3.1,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Text.Encodings.Web",4.0.0,4.0.1,MODERATE,CWE-20
+CVE-2017-0256,2018-10-16T19:57:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc","System.Text.Encodings.Web",4.3.0,4.3.1,MODERATE,CWE-20
+CVE-2017-0907,2018-10-16T17:35:04Z,"Critical severity vulnerability that affects recurly-api-client",recurly-api-client,0,1.0.1,CRITICAL,CWE-918
+CVE-2017-0907,2018-10-16T17:35:04Z,"Critical severity vulnerability that affects recurly-api-client",recurly-api-client,1.1.0,1.1.10,CRITICAL,CWE-918
+CVE-2017-0907,2018-10-16T17:35:04Z,"Critical severity vulnerability that affects recurly-api-client",recurly-api-client,1.2.0,1.2.8,CRITICAL,CWE-918
+CVE-2017-0907,2018-10-16T17:35:04Z,"Critical severity vulnerability that affects recurly-api-client",recurly-api-client,1.3.0,1.3.2,CRITICAL,CWE-918
+CVE-2017-0907,2018-10-16T17:35:04Z,"Critical severity vulnerability that affects recurly-api-client",recurly-api-client,1.4.0,1.4.14,CRITICAL,CWE-918
+CVE-2017-0907,2018-10-16T17:35:04Z,"Critical severity vulnerability that affects recurly-api-client",recurly-api-client,1.5.0,1.5.3,CRITICAL,CWE-918
+CVE-2017-0907,2018-10-16T17:35:04Z,"Critical severity vulnerability that affects recurly-api-client",recurly-api-client,1.6.0,1.6.2,CRITICAL,CWE-918
+CVE-2017-0907,2018-10-16T17:35:04Z,"Critical severity vulnerability that affects recurly-api-client",recurly-api-client,1.7.0,1.7.1,CRITICAL,CWE-918
+CVE-2017-0907,2018-10-16T17:35:04Z,"Critical severity vulnerability that affects recurly-api-client",recurly-api-client,1.8.0,1.8.1,CRITICAL,CWE-918
+CVE-2017-0929,2018-10-16T17:18:12Z,"High severity vulnerability that affects DotNetNuke.Core",DotNetNuke.Core,0,9.2.0,HIGH,CWE-918
+CVE-2017-11767,2022-05-13T01:42:32Z,"ChakraCore vulnerable to privilege escalation",Microsoft.ChakraCore,0,1.6.2,CRITICAL,CWE-119
+CVE-2017-11770,2022-04-12T00:07:34Z,"Improper Certificate Validation",Microsoft.NETCore.App,1.0.0,2.0.3,HIGH,CWE-295
+CVE-2017-11770,2022-04-12T00:07:34Z,"Improper Certificate Validation","System.Security.Cryptography.X509Certificates",4.0.0,4.1.2,HIGH,CWE-295
+CVE-2017-11792,2022-05-17T00:32:12Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.3,HIGH,CWE-119
+CVE-2017-11796,2022-05-17T00:32:03Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.3,HIGH,CWE-119
+CVE-2017-11797,2022-05-17T00:32:27Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.3,HIGH,CWE-200
+CVE-2017-11801,2022-05-17T00:32:27Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.3,HIGH,CWE-200
+CVE-2017-11805,2022-05-17T00:32:03Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.3,HIGH,CWE-119
+CVE-2017-11806,2022-05-17T00:32:03Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.3,HIGH,CWE-119
+CVE-2017-11807,2022-05-17T00:32:03Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.3,HIGH,CWE-119
+CVE-2017-11821,2022-05-17T00:32:12Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.3,HIGH,CWE-119
+CVE-2017-11862,2022-05-17T00:19:55Z,"Chakra Core vulnerable to privilege escalation due to type confusion",Microsoft.ChakraCore,0,1.7.4,HIGH,CWE-119
+CVE-2017-11870,2022-05-17T00:19:55Z,"Chakra Core vulnerable to privilege escalation when writing to JavaScript null scope objects",Microsoft.ChakraCore,0,1.7.4,HIGH,CWE-119
+CVE-2017-11871,2022-05-17T00:19:54Z,"Chakra Core vulnerable to privilege escalation due to reading an invalid pointer",Microsoft.ChakraCore,0,1.7.4,HIGH,CWE-119
+CVE-2017-11879,2022-05-14T03:47:22Z,"Open redirect in ASP.NET Core",Microsoft.AspNetCore.All,2.0.0,2.0.3,HIGH,CWE-601
+CVE-2017-11879,2022-05-14T03:47:22Z,"Open redirect in ASP.NET Core","Microsoft.AspNetCore.Mvc.Core",2.0.0,2.0.1,HIGH,CWE-601
+CVE-2017-11883,2022-05-13T01:42:35Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.Server.HttpSys",2.0.0,2.0.2,HIGH,
+CVE-2017-11883,2022-05-13T01:42:35Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.Server.WebListener",1.0.0,1.0.6,HIGH,
+CVE-2017-11883,2022-05-13T01:42:35Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.Server.WebListener",1.1.0,1.1.4,HIGH,
+CVE-2017-11883,2022-05-13T01:42:35Z,"Denial of service in ASP.NET Core","Microsoft.Net.Http.Server",1.0.0,1.0.6,HIGH,
+CVE-2017-11883,2022-05-13T01:42:35Z,"Denial of service in ASP.NET Core","Microsoft.Net.Http.Server",1.1.0,1.1.4,HIGH,
+CVE-2017-11889,2022-05-14T04:03:59Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.5,HIGH,CWE-119
+CVE-2017-11893,2022-05-14T01:06:50Z,"ChakraCore vulnerable to remote code execution",Microsoft.ChakraCore,0,1.7.5,HIGH,CWE-119
+CVE-2017-11905,2022-05-14T04:04:14Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.5,HIGH,CWE-119
+CVE-2017-11908,2022-05-17T00:11:39Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.5,HIGH,CWE-119
+CVE-2017-11909,2022-05-14T01:06:51Z,"ChakraCore vulnerable to remote code execution",Microsoft.ChakraCore,0,1.7.5,HIGH,CWE-119
+CVE-2017-11910,2022-05-17T00:11:59Z,"ChakraCore vulnerable to remote code execution due to insufficient InlineCache check",Microsoft.ChakraCore,0,1.7.5,HIGH,CWE-119
+CVE-2017-11911,2022-05-14T01:06:51Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.5,HIGH,CWE-119
+CVE-2017-11914,2022-05-14T01:06:51Z,"ChakraCore vulnerable to privilege escalation due to exposure from scriptFunction",Microsoft.ChakraCore,0,1.7.5,HIGH,CWE-119
+CVE-2017-11916,2022-05-17T00:11:58Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.7.5,HIGH,CWE-119
+CVE-2017-15279,2022-05-17T00:30:20Z,"Umbraco CMS vulnerable to stored XSS",UmbracoCMS.Web,0,7.7.3,MODERATE,CWE-79
+CVE-2017-15280,2022-05-17T00:30:20Z,"Umbraco CMS XXE Vulnerability",UmbracoCms.Web,0,7.7.3,MODERATE,CWE-611
+CVE-2017-8585,2022-05-17T00:19:03Z,"Improper Input Validation in Microsoft.NETCore.App",Microsoft.NETCore.App,1.0.0,1.0.7,HIGH,CWE-20
+CVE-2017-8585,2022-05-17T00:19:03Z,"Improper Input Validation in Microsoft.NETCore.App",Microsoft.NETCore.App,1.1.0,1.1.4,HIGH,CWE-20
+CVE-2017-8658,2022-05-17T01:57:42Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.6.1,CRITICAL,CWE-119
+CVE-2017-8659,2022-05-17T02:13:52Z,"ChakraCore information disclosure vulnerability",Microsoft.ChakraCore,0,1.6.1,MODERATE,CWE-200
+CVE-2017-8700,2022-05-13T01:47:40Z,"Cross-origin Resource Sharing bypass in ASP.NET Core","Microsoft.AspNetCore.Mvc.Core",1.0.0,1.0.6,HIGH,
+CVE-2017-8700,2022-05-13T01:47:40Z,"Cross-origin Resource Sharing bypass in ASP.NET Core","Microsoft.AspNetCore.Mvc.Core",1.1.0,1.1.6,HIGH,
+CVE-2017-8700,2022-05-13T01:47:40Z,"Cross-origin Resource Sharing bypass in ASP.NET Core","Microsoft.AspNetCore.Mvc.Cors",1.0.0,1.0.6,HIGH,
+CVE-2017-8700,2022-05-13T01:47:40Z,"Cross-origin Resource Sharing bypass in ASP.NET Core","Microsoft.AspNetCore.Mvc.Cors",1.1.0,1.1.6,HIGH,
+CVE-2017-9246,2022-05-17T02:35:57Z,"New Relic .NET Agent contains SQL Injection",NewRelic.Agent,0,6.3.123.0,CRITICAL,CWE-89
+CVE-2017-9785,2022-05-17T02:26:07Z,"Deserialization of Untrusted Data in NancyFX Nancy",Nancy,0,1.4.4,CRITICAL,CWE-502
+CVE-2017-9785,2022-05-17T02:26:07Z,"Deserialization of Untrusted Data in NancyFX Nancy",Nancy,2.0.0-alpha,2.0.0,CRITICAL,CWE-502
+CVE-2017-9822,2018-10-16T19:34:22Z,"DNN (aka DotNetNuke) has Remote Code Execution via a cookie",DotNetNuke.Core,0,9.1.1,HIGH,CWE-20
+CVE-2018-0764,2018-10-16T17:34:00Z,"Denial of service vulnerability exists when .NET and .NET Core improperly process XML documents","System.Security.Cryptography.Xml",0,4.4.2,HIGH,
+CVE-2018-0765,2018-10-16T19:54:06Z,"Denial of service vulnerability exists when .NET and .NET Core improperly process XML documents","System.Security.Cryptography.Xml",0,4.4.2,HIGH,CWE-611
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","Microsoft.NETCore.UniversalWindowsPlatform",5.2.0,5.2.4,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","Microsoft.NETCore.UniversalWindowsPlatform",5.3.0,5.3.5,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","Microsoft.NETCore.UniversalWindowsPlatform",5.4.0,5.4.2,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","Microsoft.NETCore.UniversalWindowsPlatform",6.0.0,6.0.6,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.Private.ServiceModel",4.1.0,4.1.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.Private.ServiceModel",4.3.0,4.3.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.Private.ServiceModel",4.4.0,4.4.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Duplex",4.0.1,4.0.2,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Duplex",4.3.0,4.3.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Duplex",4.4.0,4.4.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components",System.ServiceModel.Http,4.1.0,4.1.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components",System.ServiceModel.Http,4.3.0,4.3.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components",System.ServiceModel.Http,4.4.0,4.4.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.NetTcp",4.1.0,4.1.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.NetTcp",4.3.0,4.3.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.NetTcp",4.4.0,4.4.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Primitives",4.1.0,4.1.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Primitives",4.3.0,4.3.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Primitives",4.4.0,4.4.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Security",4.0.1,4.0.2,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Security",4.3.0,4.3.1,HIGH,CWE-295
+CVE-2018-0786,2018-10-16T19:59:05Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Security",4.4.0,4.4.1,HIGH,CWE-295
+CVE-2018-0787,2018-10-16T19:56:59Z,"ASP.NET Core allow an elevation of privilege","Microsoft.AspNetCore.HttpOverrides",2.0.0,2.0.2,HIGH,CWE-640
+CVE-2018-0787,2018-10-16T19:56:59Z,"ASP.NET Core allow an elevation of privilege","Microsoft.AspNetCore.Server.Kestrel.Core",2.0.0,2.0.2,HIGH,CWE-640
+CVE-2018-0818,2022-05-13T01:48:24Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.0,HIGH,
+CVE-2018-0834,2022-05-13T01:18:32Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.1,HIGH,CWE-787
+CVE-2018-0835,2022-05-13T01:18:31Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.1,HIGH,CWE-787
+CVE-2018-0836,2022-05-13T01:18:32Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.1,HIGH,CWE-787
+CVE-2018-0837,2022-05-13T01:18:32Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.1,HIGH,CWE-787
+CVE-2018-0838,2022-05-13T01:18:33Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.1,HIGH,CWE-787
+CVE-2018-0856,2022-05-13T01:18:34Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.1,HIGH,CWE-787
+CVE-2018-0857,2022-05-13T01:18:33Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.1,HIGH,CWE-787
+CVE-2018-0858,2022-05-13T01:18:34Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.1,HIGH,CWE-787
+CVE-2018-0859,2022-05-13T01:18:33Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.1,HIGH,CWE-787
+CVE-2018-0860,2022-05-13T01:18:33Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.1,HIGH,CWE-787
+CVE-2018-0872,2022-05-13T01:18:35Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.2,HIGH,CWE-787
+CVE-2018-0873,2022-05-13T01:18:35Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.2,HIGH,CWE-787
+CVE-2018-0874,2022-05-13T01:18:35Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.2,HIGH,CWE-787
+CVE-2018-0875,2022-05-13T01:07:06Z,".NET Core Denial of Service Vulnerability",Microsoft.NETCore.Jit,0,1.0.12,HIGH,
+CVE-2018-0875,2022-05-13T01:07:06Z,".NET Core Denial of Service Vulnerability",Microsoft.NETCore.Jit,1.1.0,1.1.7,HIGH,
+CVE-2018-0875,2022-05-13T01:07:06Z,".NET Core Denial of Service Vulnerability",Microsoft.NETCore.Jit,2.0.0,2.0.6,HIGH,
+CVE-2018-0925,2022-05-13T01:18:37Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.2,HIGH,CWE-787
+CVE-2018-0930,2022-05-13T01:18:37Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.2,HIGH,CWE-787
+CVE-2018-0931,2022-05-13T01:18:37Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.2,HIGH,CWE-787
+CVE-2018-0933,2022-05-13T01:18:37Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.2,HIGH,CWE-787
+CVE-2018-0934,2022-05-13T01:18:38Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.2,HIGH,CWE-787
+CVE-2018-0936,2022-05-13T01:18:38Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.2,HIGH,CWE-787
+CVE-2018-0937,2022-05-13T01:18:38Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.2,HIGH,CWE-787
+CVE-2018-0939,2022-05-13T01:18:38Z,"ChakraCore information disclosure vulnerability",Microsoft.ChakraCore,0,1.8.2,MODERATE,CWE-787
+CVE-2018-0943,2022-05-13T01:18:37Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-787
+CVE-2018-0945,2022-05-13T01:18:39Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-787
+CVE-2018-0946,2022-05-13T01:18:39Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-787
+CVE-2018-0954,2022-05-13T01:18:39Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-787
+CVE-2018-0979,2022-05-13T01:18:41Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.3,HIGH,CWE-787
+CVE-2018-0980,2022-05-13T01:18:41Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.3,HIGH,CWE-787
+CVE-2018-0990,2022-05-13T01:18:42Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.3,HIGH,CWE-787
+CVE-2018-0993,2022-05-13T01:18:42Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.3,HIGH,CWE-787
+CVE-2018-0994,2022-05-13T01:18:42Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.3,HIGH,CWE-787
+CVE-2018-0995,2022-05-13T01:18:42Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.3,HIGH,CWE-787
+CVE-2018-1000120,2022-05-14T00:58:02Z,"curl FTP path confusion leads to NIL byte out of bounds write",curl,7.12.3,,CRITICAL,CWE-787
+CVE-2018-1000210,2018-10-16T17:01:10Z,"High severity vulnerability that affects YamlDotNet and YamlDotNet.Signed",YamlDotNet,0,5.0.0,HIGH,CWE-502;CWE-639
+CVE-2018-1000210,2018-10-16T17:01:10Z,"High severity vulnerability that affects YamlDotNet and YamlDotNet.Signed",YamlDotNet.Signed,0,5.0.0,HIGH,CWE-502;CWE-639
+CVE-2018-1002205,2018-10-16T17:16:40Z,"High severity vulnerability that affects DotNetZip",DotNetZip,0,1.11.0,HIGH,CWE-22
+CVE-2018-1002206,2019-09-11T22:59:57Z,"Directory Traversal in SharpCompress",SharpCompress,0,0.21.0,MODERATE,CWE-22
+CVE-2018-1002208,2022-05-13T01:35:03Z,"Improper Limitation of a Pathname to a Restricted Directory in SharpZipLib",SharpZipLib,0,1.0.0-rc1,MODERATE,CWE-22
+CVE-2018-1019,2022-05-13T01:18:49Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.3,HIGH,CWE-787
+CVE-2018-1022,2022-05-13T01:18:49Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-787
+CVE-2018-12086,2018-10-16T19:51:31Z,"High severity vulnerability that affects OPCFoundation.NetStandard.Opc.Ua","OPCFoundation.NetStandard.Opc.Ua",0,1.4.353.15,HIGH,CWE-787
+CVE-2018-12087,2018-10-16T19:51:18Z,"Moderate severity vulnerability that affects OPCFoundation.NetStandard.Opc.Ua","OPCFoundation.NetStandard.Opc.Ua",0,1.4.353.15,MODERATE,CWE-295
+CVE-2018-1285,2021-01-29T19:47:23Z,"XML External Entity attack in log4net",log4net,0,2.0.10,CRITICAL,CWE-611
+CVE-2018-14040,2022-05-13T01:07:54Z,"Bootstrap vulnerable to Cross-Site Scripting (XSS)",bootstrap,2.3.0,3.4.0,MODERATE,CWE-79
+CVE-2018-14040,2022-05-13T01:07:54Z,"Bootstrap vulnerable to Cross-Site Scripting (XSS)",bootstrap,4.0.0,4.1.2,MODERATE,CWE-79
+CVE-2018-14040,2022-05-13T01:07:54Z,"Bootstrap vulnerable to Cross-Site Scripting (XSS)",bootstrap.sass,4.0.0,4.1.2,MODERATE,CWE-79
+CVE-2018-14041,2018-09-13T15:49:56Z,"Bootstrap Cross-site Scripting vulnerability",bootstrap,4.0.0,4.1.2,MODERATE,CWE-79
+CVE-2018-14041,2018-09-13T15:49:56Z,"Bootstrap Cross-site Scripting vulnerability",bootstrap.sass,4.0.0,4.1.2,MODERATE,CWE-79
+CVE-2018-14042,2018-09-13T15:50:32Z,"Bootstrap Cross-site Scripting vulnerability",bootstrap,2.3.0,3.4.0,MODERATE,CWE-79
+CVE-2018-14042,2018-09-13T15:50:32Z,"Bootstrap Cross-site Scripting vulnerability",bootstrap,4.0.0,4.1.2,MODERATE,CWE-79
+CVE-2018-14042,2018-09-13T15:50:32Z,"Bootstrap Cross-site Scripting vulnerability",bootstrap.sass,4.0.0,4.1.2,MODERATE,CWE-79
+CVE-2018-14486,2022-05-14T01:17:48Z,"DNN XSS Vulnerability",DotNetNuke.Core,0,,MODERATE,CWE-79
+CVE-2018-14550,2021-03-22T16:57:07Z,"Out-of-bounds write in libpng",libpng,0,1.6.37,HIGH,CWE-787
+CVE-2018-15121,2022-05-14T02:01:18Z,"Auth0-ASPNET and Auth0-ASPNET-Owin vulnerable to Cross-Site Request Forgery",auth0-aspnet,0,,HIGH,CWE-352
+CVE-2018-15121,2022-05-14T02:01:18Z,"Auth0-ASPNET and Auth0-ASPNET-Owin vulnerable to Cross-Site Request Forgery",Auth0-ASPNET-Owin,0,,HIGH,CWE-352
+CVE-2018-15811,2019-07-05T21:08:36Z,"Inadequate Encryption Strength in DotNetNuke",DotNetNuke.Core,9.2.0,9.2.2,HIGH,CWE-326
+CVE-2018-15812,2019-07-05T21:08:24Z,"Insufficient Entropy in DotNetNuke",DotNetNuke.Core,9.2.0,9.2.2,HIGH,CWE-331
+CVE-2018-17060,2022-05-13T01:19:22Z,"Improper Access Control in Telerik Extensions",TelerikMvcExtensions,0,,MODERATE,CWE-284
+CVE-2018-17107,2023-06-12T20:30:27Z,"tgstation-server cached user logins in legacy server",TGServiceInterface,3.2.1.0,3.2.5.0,HIGH,
+CVE-2018-17256,2022-05-14T01:44:31Z,"Umbraco CMS vulnerable to stored XSS",umbraco,0,,MODERATE,CWE-79
+CVE-2018-18325,2019-07-05T21:08:16Z,"Inadequate Encryption Strength in DotNetNuke",DotNetNuke.Core,0,9.3.0,HIGH,CWE-326
+CVE-2018-18326,2019-07-05T21:08:20Z,"Insufficient Entropy in DotNetNuke",DotNetNuke.Core,0,9.3.0,HIGH,CWE-331
+CVE-2018-20676,2019-01-17T13:57:34Z,"XSS vulnerability that affects bootstrap",bootstrap,0,3.4.0,MODERATE,CWE-79
+CVE-2018-20677,2019-01-17T13:57:56Z,"bootstrap Cross-site Scripting vulnerability",bootstrap,0,3.4.0,MODERATE,CWE-79
+CVE-2018-7559,2018-10-16T19:58:42Z,"OPC UA applications can allow a remote attacker to determine a Server's private key ","OPCFoundation.NetStandard.Opc.Ua",0,1.3.352.12,MODERATE,
+CVE-2018-8130,2022-05-13T01:20:39Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-787
+CVE-2018-8133,2022-05-13T01:20:39Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-843
+CVE-2018-8137,2022-05-13T01:20:39Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-787
+CVE-2018-8139,2022-05-13T01:20:40Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-125
+CVE-2018-8145,2022-05-13T01:53:32Z,"ChakraCore information disclosure vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-200
+CVE-2018-8171,2018-10-16T19:56:50Z,"Security feature bypass vulnerability exists in ASP.NET when the number of incorrect login attempts is not validated","Microsoft.AspNetCore.Identity",1.0.0,1.0.6,HIGH,CWE-287
+CVE-2018-8171,2018-10-16T19:56:50Z,"Security feature bypass vulnerability exists in ASP.NET when the number of incorrect login attempts is not validated","Microsoft.AspNetCore.Identity",1.1.0,1.1.6,HIGH,CWE-287
+CVE-2018-8171,2018-10-16T19:56:50Z,"Security feature bypass vulnerability exists in ASP.NET when the number of incorrect login attempts is not validated","Microsoft.AspNetCore.Identity",2.0.0,2.0.4,HIGH,CWE-287
+CVE-2018-8171,2018-10-16T19:56:50Z,"Security feature bypass vulnerability exists in ASP.NET when the number of incorrect login attempts is not validated","Microsoft.AspNetCore.Identity",2.1.0,2.1.2,HIGH,CWE-287
+CVE-2018-8177,2022-05-13T01:20:41Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.4,HIGH,CWE-787
+CVE-2018-8227,2022-05-13T01:20:43Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.5,HIGH,CWE-787
+CVE-2018-8229,2022-05-13T01:20:42Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.5,HIGH,CWE-843
+CVE-2018-8243,2022-05-13T01:20:43Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.8.5,HIGH,CWE-787
+CVE-2018-8266,2022-05-13T01:20:43Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.2,HIGH,CWE-787
+CVE-2018-8269,2018-10-16T19:58:31Z,"Denial of service in ASP.NET Core",Microsoft.AspNetCore.All,2.1.0,2.1.13,HIGH,
+CVE-2018-8269,2018-10-16T19:58:31Z,"Denial of service in ASP.NET Core",Microsoft.AspNetCore.All,2.2.0,2.2.7,HIGH,
+CVE-2018-8269,2018-10-16T19:58:31Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.DataProtection.AzureStorage",2.1.0,2.1.13,HIGH,
+CVE-2018-8269,2018-10-16T19:58:31Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.DataProtection.AzureStorage",2.2.0,2.2.7,HIGH,
+CVE-2018-8269,2018-10-16T19:58:31Z,"Denial of service in ASP.NET Core",Microsoft.Data.OData,0,5.8.4,HIGH,
+CVE-2018-8276,2022-05-13T01:53:37Z,"ChakraCore Security Bypass",Microsoft.ChakraCore,0,1.10.1,MODERATE,
+CVE-2018-8280,2022-05-13T01:20:44Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.1,HIGH,CWE-787
+CVE-2018-8283,2022-05-13T01:20:44Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.1,HIGH,CWE-787
+CVE-2018-8286,2022-05-13T01:20:45Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.1,HIGH,CWE-787
+CVE-2018-8287,2022-05-13T01:20:45Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.1,HIGH,CWE-787
+CVE-2018-8288,2022-05-13T01:20:46Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.1,HIGH,CWE-787
+CVE-2018-8290,2022-05-13T01:20:46Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.1,HIGH,CWE-787
+CVE-2018-8291,2022-05-13T01:20:46Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.1,HIGH,CWE-843
+CVE-2018-8292,2021-04-21T19:16:06Z,".NET Core Information Disclosure",System.Net.Http,0,4.3.4,HIGH,CWE-200
+CVE-2018-8294,2022-05-13T01:20:46Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.1,HIGH,CWE-787
+CVE-2018-8298,2022-05-13T01:20:46Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.1,HIGH,CWE-843
+CVE-2018-8315,2022-05-14T02:03:04Z,"ChakraCore information disclosure vulnerability",Microsoft.ChakraCore,0,1.11.1,MODERATE,CWE-200
+CVE-2018-8354,2022-05-13T01:20:48Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.1,HIGH,CWE-787
+CVE-2018-8355,2022-05-13T01:20:48Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.2,HIGH,CWE-787
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.Private.ServiceModel",4.0.0,4.1.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.Private.ServiceModel",4.3.0,4.3.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.Private.ServiceModel",4.4.0,4.4.4,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.Private.ServiceModel",4.5.0,4.5.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Duplex",4.0.0,4.0.4,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Duplex",4.3.0,4.3.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Duplex",4.4.0,4.4.4,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Duplex",4.5.0,4.5.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components",System.ServiceModel.Http,4.0.0,4.1.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components",System.ServiceModel.Http,4.3.0,4.3.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components",System.ServiceModel.Http,4.4.0,4.4.4,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components",System.ServiceModel.Http,4.5.0,4.5.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.NetTcp",4.0.0,4.1.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.NetTcp",4.3.0,4.3.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.NetTcp",4.4.0,4.4.4,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.NetTcp",4.5.0,4.5.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Primitives",4.0.0,4.1.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Primitives",4.3.0,4.3.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Primitives",4.4.0,4.4.4,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Primitives",4.5.0,4.5.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Security",4.0.0,4.0.4,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Security",4.3.0,4.3.3,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Security",4.4.0,4.4.4,MODERATE,CWE-295
+CVE-2018-8356,2022-05-14T03:00:10Z,"Improper Certificate Validation in Microsoft .NET Framework components","System.ServiceModel.Security",4.5.0,4.5.3,MODERATE,CWE-295
+CVE-2018-8359,2022-05-13T01:20:49Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.2,HIGH,CWE-787
+CVE-2018-8367,2022-05-13T01:20:49Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.1,HIGH,CWE-787
+CVE-2018-8371,2022-05-13T01:20:49Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.1,HIGH,CWE-787
+CVE-2018-8372,2022-05-13T01:20:49Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.2,HIGH,CWE-787
+CVE-2018-8380,2022-05-13T01:20:50Z,"ChakraCore remote code execution vulnerability",Microsoft.ChakraCore,0,1.10.2,HIGH,CWE-787
+CVE-2018-8381,2022-05-13T01:20:50Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.2,HIGH,CWE-787
+CVE-2018-8384,2022-05-13T01:20:51Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.2,HIGH,CWE-843
+CVE-2018-8385,2022-05-13T01:20:51Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.2,HIGH,CWE-787
+CVE-2018-8390,2022-05-13T01:20:51Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.10.2,HIGH,CWE-787
+CVE-2018-8391,2022-05-13T01:20:52Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.1,HIGH,CWE-787
+CVE-2018-8409,2018-10-16T19:56:38Z,"Denial of service vulnerability exists when System.IO.Pipelines improperly handles requests",Microsoft.AspNetCore.All,2.1.0,2.1.4,HIGH,
+CVE-2018-8409,2018-10-16T19:56:38Z,"Denial of service vulnerability exists when System.IO.Pipelines improperly handles requests",Microsoft.AspNetCore.App,2.1.0,2.1.4,HIGH,
+CVE-2018-8409,2018-10-16T19:56:38Z,"Denial of service vulnerability exists when System.IO.Pipelines improperly handles requests",System.IO.Pipelines,4.5.0,4.5.1,HIGH,
+CVE-2018-8416,2022-05-13T01:20:52Z,"Tampering vulnerability in .NET Core",Microsoft.NETCore.App,2.1.0,2.1.7,MODERATE,
+CVE-2018-8452,2022-05-13T01:53:42Z,"ChakraCore information disclosure vulnerability",Microsoft.ChakraCore,0,1.11.1,MODERATE,CWE-200
+CVE-2018-8456,2022-05-13T01:20:53Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.1,HIGH,CWE-787
+CVE-2018-8459,2022-05-13T01:20:53Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.1,HIGH,CWE-787
+CVE-2018-8465,2022-05-13T01:20:54Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.1,HIGH,CWE-787
+CVE-2018-8466,2022-05-13T01:20:55Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.1,HIGH,CWE-787
+CVE-2018-8467,2022-05-13T01:20:55Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.1,HIGH,CWE-787
+CVE-2018-8500,2022-05-13T01:20:55Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.2,CRITICAL,CWE-787
+CVE-2018-8503,2022-05-13T01:20:56Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.2,HIGH,CWE-787
+CVE-2018-8505,2022-05-13T01:20:56Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.2,HIGH,CWE-787
+CVE-2018-8510,2022-05-13T01:20:56Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.2,HIGH,CWE-787
+CVE-2018-8511,2022-05-13T01:20:57Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.2,HIGH,CWE-787
+CVE-2018-8513,2022-05-13T01:20:57Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.2,HIGH,CWE-787
+CVE-2018-8541,2022-05-13T01:20:57Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.3,HIGH,CWE-787
+CVE-2018-8542,2022-05-13T01:20:58Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.3,HIGH,CWE-787
+CVE-2018-8543,2022-05-13T01:20:58Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.3,HIGH,CWE-787
+CVE-2018-8551,2022-05-13T01:20:58Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.3,HIGH,CWE-787
+CVE-2018-8555,2022-05-13T01:20:58Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.3,HIGH,CWE-787
+CVE-2018-8556,2022-05-13T01:20:59Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.3,HIGH,CWE-787
+CVE-2018-8557,2022-05-13T01:20:59Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.3,HIGH,CWE-787
+CVE-2018-8583,2022-05-13T01:21:01Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.3,HIGH,CWE-787
+CVE-2018-8588,2022-05-13T01:21:01Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.3,HIGH,CWE-787
+CVE-2018-8617,2022-05-13T01:21:02Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.3,HIGH,CWE-787
+CVE-2018-8618,2022-05-13T01:21:02Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.4,HIGH,CWE-787
+CVE-2018-8624,2022-05-13T01:21:03Z,"ChakraCore Remote code execution Vulnerability",Microsoft.ChakraCore,0,1.11.4,HIGH,CWE-787
+CVE-2018-8629,2022-05-13T01:21:03Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.4,HIGH,CWE-787
+CVE-2019-0539,2022-05-13T01:21:15Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.5,HIGH,CWE-787
+CVE-2019-0545,2022-05-14T01:41:10Z,"Exposure of Sensitive Information in System.Net.Http",Microsoft.NETCore.App,2.1.0,2.1.7,HIGH,CWE-200
+CVE-2019-0545,2022-05-14T01:41:10Z,"Exposure of Sensitive Information in System.Net.Http",Microsoft.NETCore.App,2.2.0,2.2.1,HIGH,CWE-200
+CVE-2019-0564,2022-05-14T01:41:32Z,"Denial of service in ASP.NET Core",Microsoft.AspNetCore.All,2.1.0,2.1.7,HIGH,
+CVE-2019-0564,2022-05-14T01:41:32Z,"Denial of service in ASP.NET Core",Microsoft.AspNetCore.All,2.2.0,2.2.1,HIGH,
+CVE-2019-0564,2022-05-14T01:41:32Z,"Denial of service in ASP.NET Core",Microsoft.AspNetCore.App,2.1.0,2.1.7,HIGH,
+CVE-2019-0564,2022-05-14T01:41:32Z,"Denial of service in ASP.NET Core",Microsoft.AspNetCore.App,2.2.0,2.2.1,HIGH,
+CVE-2019-0564,2022-05-14T01:41:32Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.Server.Kestrel.Core",2.1.0,2.1.7,HIGH,
+CVE-2019-0564,2022-05-14T01:41:32Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.WebSockets",2.1.0,2.1.7,HIGH,
+CVE-2019-0564,2022-05-14T01:41:32Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.WebSockets",2.2.0,2.2.1,HIGH,
+CVE-2019-0564,2022-05-14T01:41:32Z,"Denial of service in ASP.NET Core",Microsoft.NETCore.App,2.1.0,2.1.7,HIGH,
+CVE-2019-0564,2022-05-14T01:41:32Z,"Denial of service in ASP.NET Core",Microsoft.NETCore.App,2.2.0,2.2.1,HIGH,
+CVE-2019-0564,2022-05-14T01:41:32Z,"Denial of service in ASP.NET Core","System.Net.WebSockets.WebSocketProtocol",4.5.0,4.5.3,HIGH,
+CVE-2019-0567,2022-05-13T01:21:17Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.5,HIGH,CWE-787
+CVE-2019-0568,2022-05-13T01:21:17Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.5,HIGH,CWE-787
+CVE-2019-0592,2019-04-09T19:43:56Z,"High severity vulnerability that affects Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.7,HIGH,CWE-787
+CVE-2019-0609,2019-04-09T19:43:59Z,"High severity vulnerability that affects Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.7,HIGH,CWE-787
+CVE-2019-0611,2019-04-09T19:43:54Z,"High severity vulnerability that affects Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.7,HIGH,CWE-787
+CVE-2019-0639,2019-04-09T19:44:03Z,"High severity vulnerability that affects Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.7,HIGH,CWE-190
+CVE-2019-0648,2022-05-13T01:21:25Z,"ChakraCore information disclosure vulnerability",Microsoft.ChakraCore,0,1.11.6,MODERATE,
+CVE-2019-0649,2022-05-13T01:21:26Z,"Chakra JIT server Privilege Escalation ",Microsoft.ChakraCore,0,1.11.6,HIGH,
+CVE-2019-0657,2022-05-14T01:28:01Z,"Improper Input Validation in .Net Framework API's",Microsoft.NETCore.App,2.1.0,2.1.8,MODERATE,CWE-20
+CVE-2019-0657,2022-05-14T01:28:01Z,"Improper Input Validation in .Net Framework API's",Microsoft.NETCore.App,2.2.0,2.2.2,MODERATE,CWE-20
+CVE-2019-0657,2022-05-14T01:28:01Z,"Improper Input Validation in .Net Framework API's",System.Private.Uri,4.3.0,4.3.2,MODERATE,CWE-20
+CVE-2019-0746,2019-04-09T19:43:38Z,"Microsoft.ChakraCore vulnerable to Exposure of Sensitive Information to an Unauthorized Actor ",Microsoft.ChakraCore,0,1.11.7,MODERATE,CWE-200
+CVE-2019-0769,2019-04-09T19:43:46Z,"High severity vulnerability that affects Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.7,HIGH,CWE-787
+CVE-2019-0771,2019-04-09T19:43:29Z,"High severity vulnerability that affects Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.7,HIGH,CWE-787
+CVE-2019-0773,2019-04-09T19:43:32Z,"High severity vulnerability that affects Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.7,HIGH,CWE-787
+CVE-2019-0806,2022-05-13T01:21:36Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.8,HIGH,CWE-787
+CVE-2019-0810,2022-05-13T01:21:36Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.8,HIGH,CWE-787
+CVE-2019-0812,2022-05-13T01:21:36Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.8,HIGH,CWE-787
+CVE-2019-0820,2021-08-04T21:03:46Z,"Regular Expression Denial of Service in System.Text.RegularExpressions","System.Text.RegularExpressions",4.3.0,4.3.1,HIGH,CWE-1333;CWE-400
+CVE-2019-0829,2022-05-13T01:21:37Z,"ChakraCore Memory Corruption Vulnerability",Microsoft.ChakraCore,0,1.11.8,HIGH,CWE-787
+CVE-2019-0860,2022-05-13T01:21:40Z,"ChakraCore Memory Corruption Vulnerability",Microsoft.ChakraCore,0,1.11.8,HIGH,CWE-787
+CVE-2019-0861,2022-05-13T01:21:41Z,"ChakraCore Memory Corruption Vulnerability",Microsoft.ChakraCore,0,1.11.8,HIGH,CWE-787
+CVE-2019-0911,2021-03-29T21:00:00Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0912,2021-03-29T20:59:59Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0913,2021-03-29T21:00:05Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0914,2021-03-29T21:00:02Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0915,2021-03-29T21:00:03Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0916,2021-03-29T21:00:09Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0917,2021-03-29T21:00:06Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0922,2021-03-29T21:00:11Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0923,2021-03-29T21:00:08Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0924,2021-03-29T21:00:12Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0925,2021-03-29T20:57:39Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0927,2021-03-29T20:58:59Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0933,2021-03-29T20:59:01Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0937,2021-03-29T20:59:03Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.9,HIGH,CWE-787
+CVE-2019-0976,2022-05-24T22:28:08Z,"NuGet Package Manager Tampering Vulnerability",NuGet.Commands,5.0.0,5.0.2,MODERATE,CWE-732
+CVE-2019-0980,2022-05-24T16:45:53Z,"Denial of service in ASP.NET Core",System.Private.Uri,4.3.0,4.3.2,HIGH,
+CVE-2019-0981,2022-05-24T16:45:54Z,"Denial of service in ASP.NET Core",System.Private.Uri,4.3.0,4.3.2,HIGH,
+CVE-2019-0982,2022-05-24T16:45:54Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.SignalR.Protocols.MessagePack",1.0.0,1.0.11,HIGH,
+CVE-2019-0982,2022-05-24T16:45:54Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.SignalR.Protocols.MessagePack",1.1.0,1.1.5,HIGH,
+CVE-2019-0989,2021-03-29T20:59:04Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.10,HIGH,CWE-787
+CVE-2019-0991,2021-03-29T20:57:42Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.10,HIGH,CWE-787
+CVE-2019-0992,2021-03-29T20:59:07Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.10,HIGH,CWE-787
+CVE-2019-0993,2021-03-29T20:57:51Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.10,HIGH,CWE-787
+CVE-2019-1002,2022-05-24T22:00:06Z,"ChakraCore RCE via Out-of-bounds write",Microsoft.ChakraCore,0,1.11.10,HIGH,CWE-787
+CVE-2019-1003,2021-03-29T20:59:06Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.10,HIGH,CWE-787
+CVE-2019-1010113,2019-07-26T16:10:06Z,"Cross-site scripting in CLEditor",CLEditor,0,,MODERATE,CWE-79
+CVE-2019-1010199,2022-05-24T22:00:16Z,"Cross site scripting attack in ServiceStack Framework",ServiceStack,4.5.14,5.2.0,MODERATE,CWE-79
+CVE-2019-1024,2022-05-24T22:00:06Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.10,HIGH,CWE-787
+CVE-2019-1051,2022-05-24T22:00:06Z,"ChakraCore RCE via Out-of-bounds write",Microsoft.ChakraCore,0,1.11.10,HIGH,CWE-787
+CVE-2019-1052,2022-05-24T22:00:06Z,"ChakraCore RCE via Out-of-bounds write",Microsoft.ChakraCore,0,1.11.10,HIGH,CWE-787
+CVE-2019-1062,2021-03-29T20:59:09Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.11,HIGH,CWE-787
+CVE-2019-1075,2022-05-24T16:50:19Z,"Open redirect in ASP.NET Core",Microsoft.AspNetCore.All,2.1.0,2.1.12,MODERATE,CWE-601
+CVE-2019-1075,2022-05-24T16:50:19Z,"Open redirect in ASP.NET Core",Microsoft.AspNetCore.All,2.2.0,2.2.6,MODERATE,CWE-601
+CVE-2019-1075,2022-05-24T16:50:19Z,"Open redirect in ASP.NET Core",Microsoft.AspNetCore.App,2.1.0,2.1.12,MODERATE,CWE-601
+CVE-2019-1075,2022-05-24T16:50:19Z,"Open redirect in ASP.NET Core",Microsoft.AspNetCore.App,2.2.0,2.2.6,MODERATE,CWE-601
+CVE-2019-1075,2022-05-24T16:50:19Z,"Open redirect in ASP.NET Core","Microsoft.AspNetCore.Server.HttpSys",2.1.0,2.1.12,MODERATE,CWE-601
+CVE-2019-1075,2022-05-24T16:50:19Z,"Open redirect in ASP.NET Core","Microsoft.AspNetCore.Server.HttpSys",2.2.0,2.2.6,MODERATE,CWE-601
+CVE-2019-1075,2022-05-24T16:50:19Z,"Open redirect in ASP.NET Core","Microsoft.AspNetCore.Server.IIS",2.2.0,2.2.6,MODERATE,CWE-601
+CVE-2019-1092,2021-03-29T20:59:11Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.11,HIGH,CWE-787
+CVE-2019-1103,2021-03-29T20:59:12Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.11,HIGH,CWE-787
+CVE-2019-1106,2021-03-29T20:59:15Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.11,HIGH,CWE-787
+CVE-2019-1107,2021-03-29T20:57:35Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.11,HIGH,CWE-787
+CVE-2019-1131,2021-03-29T20:57:46Z,"Out-of-bounds write in Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.12,HIGH,CWE-787
+CVE-2019-11358,2019-04-26T16:29:11Z,"XSS in jQuery as used in Drupal, Backdrop CMS, and other products",jQuery,1.1.4,3.4.0,MODERATE,CWE-1321;CWE-79
+CVE-2019-1138,2021-03-29T20:56:11Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.13,HIGH,CWE-787
+CVE-2019-1139,2021-03-29T20:57:53Z,"Out-of-bounds write in Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.12,HIGH,CWE-787
+CVE-2019-11401,2022-05-24T16:44:03Z,"SiteServer CMS RCE via unsafe file upload",sscms,0,6.12,HIGH,CWE-434
+CVE-2019-1140,2021-03-29T20:57:49Z,"Out-of-bounds write in Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.12,HIGH,CWE-787
+CVE-2019-1141,2021-03-29T20:57:56Z,"Out-of-bounds write in Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.12,HIGH,CWE-787
+CVE-2019-1167,2019-07-17T19:14:18Z,"System.Management.Automation subject to bypass via script debugging","System.Management.Automation",6.1.0,6.1.5,MODERATE,
+CVE-2019-1167,2019-07-17T19:14:18Z,"System.Management.Automation subject to bypass via script debugging","System.Management.Automation",6.2.0,6.2.2,MODERATE,
+CVE-2019-1195,2021-03-29T20:57:59Z,"Out-of-bounds write in Microsoft.ChakraCore",Microsoft.ChakraCore,0,1.11.12,HIGH,CWE-787
+CVE-2019-1196,2021-03-29T20:58:01Z,"Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.12,HIGH,CWE-787
+CVE-2019-1197,2021-03-29T20:56:15Z,"Out-of-bounds write ",Microsoft.ChakraCore,0,1.11.12,HIGH,CWE-787
+CVE-2019-1217,2021-03-29T20:56:08Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.13,HIGH,CWE-787
+CVE-2019-1237,2021-03-29T20:56:04Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.13,HIGH,CWE-787
+CVE-2019-12562,2019-11-18T17:16:06Z,"Stored Cross-Site Scripting vulnerability in admin component of DotNetNuke",DotNetNuke.Core,0,9.4.0,MODERATE,CWE-79
+CVE-2019-1258,2019-08-16T14:03:35Z,"Vulnerability in Azure Active Directory Authentication Library","microsoft.identitymodel.clients.activedirectory",5.0.0,5.2.0,HIGH,
+CVE-2019-1298,2021-03-29T20:56:01Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.13,HIGH,CWE-787
+CVE-2019-1300,2021-03-29T20:55:57Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.13,HIGH,CWE-787
+CVE-2019-1301,2019-09-13T13:25:47Z,"High severity vulnerability that affects System.Management.Automation","System.Management.Automation",0,6.1.6,HIGH,
+CVE-2019-1301,2019-09-13T13:25:47Z,"High severity vulnerability that affects System.Management.Automation","System.Management.Automation",6.2.0,6.2.3,HIGH,
+CVE-2019-1302,2022-05-24T22:00:33Z,"Elevation of privilege in ASP.NET Core","Microsoft.AspNetCore.SpaServices",2.1.0,2.1.13,MODERATE,
+CVE-2019-1302,2022-05-24T22:00:33Z,"Elevation of privilege in ASP.NET Core","Microsoft.AspNetCore.SpaServices",2.2.0,2.2.7,MODERATE,
+CVE-2019-1307,2021-03-29T20:55:46Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.14,HIGH,CWE-787
+CVE-2019-1308,2021-03-29T20:55:52Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.14,HIGH,CWE-787
+CVE-2019-1335,2021-03-29T20:55:40Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.14,HIGH,CWE-787
+CVE-2019-1366,2021-03-29T20:55:36Z,"Out-of-bounds write",Microsoft.ChakraCore,0,1.11.14,HIGH,CWE-787
+CVE-2019-14262,2019-08-23T00:04:56Z,"Uncontrolled Resource Consumption in MetadataExtractor",MetadataExtractor,0,2.2.0,HIGH,CWE-400
+CVE-2019-15151,2021-03-29T20:48:45Z,"Double Free in Adplug",adplug,0,2.3.3,CRITICAL,CWE-415
+CVE-2019-16929,2019-10-24T20:56:12Z,"Improper Authentication in Auth0.AuthenticationApi",Auth0.AuthenticationApi,5.8.0,6.5.4,HIGH,CWE-287
+CVE-2019-20627,2022-05-24T17:12:10Z,"AutoUpdater.NET allows XXE",Autoupdater.NET.Official,0,1.5.8,CRITICAL,CWE-611
+CVE-2019-20921,2021-05-07T16:47:54Z,"Cross-site scripting in bootstrap-select",bootstrap-select,0,1.13.6,MODERATE,CWE-79
+CVE-2019-5428,2019-04-23T15:59:10Z,"Duplicate Advisory: Prototype Pollution in jquery",jquery,0,3.4.0,MODERATE,
+CVE-2019-7644,2019-04-18T14:28:03Z,"Critical severity vulnerability that affects Auth0-WCF-Service-JWT",Auth0-WCF-Service-JWT,0,1.0.4,CRITICAL,CWE-209
+CVE-2019-8331,2019-02-22T20:54:47Z,"Bootstrap Vulnerable to Cross-Site Scripting",bootstrap,3.0.0,3.4.1,MODERATE,CWE-79
+CVE-2019-8331,2019-02-22T20:54:47Z,"Bootstrap Vulnerable to Cross-Site Scripting",bootstrap,4.0.0,4.3.1,MODERATE,CWE-79
+CVE-2019-8331,2019-02-22T20:54:47Z,"Bootstrap Vulnerable to Cross-Site Scripting",Bootstrap.Less,3.0.0,3.4.1,MODERATE,CWE-79
+CVE-2019-8331,2019-02-22T20:54:47Z,"Bootstrap Vulnerable to Cross-Site Scripting",bootstrap.sass,0,4.3.1,MODERATE,CWE-79
+CVE-2019-9648,2022-05-14T00:52:11Z,"CoreFTP Directory Traversal",CoreFtp,0,,MODERATE,CWE-22
+CVE-2019-9845,2019-07-05T21:11:13Z,"MadsKristensen.AspNetCore.Miniblog subject to Improper Input Validation","MadsKristensen.AspNetCore.Miniblog",0,,CRITICAL,CWE-20
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core",Microsoft.AspNetCore.All,2.1.0,2.1.15,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core",Microsoft.AspNetCore.App,2.1.0,2.1.15,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core",Microsoft.AspNetCore.App,3.0.0,3.0.1,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core",Microsoft.AspNetCore.App,3.1.0,3.1.1,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.linux-arm",3.1.0,3.1.1,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.1.0,3.1.1,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.1.0,3.1.1,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.linux-x64",3.1.0,3.1.1,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.osx-x64",3.1.0,3.1.1,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.win-arm",3.1.0,3.1.1,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.win-x64",3.1.0,3.1.1,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.win-x86",3.1.0,3.1.1,MODERATE,CWE-400
+CVE-2020-0602,2022-05-24T17:06:16Z,"Denial of service in ASP.NET Core","Microsoft.AspNetCore.Http.Connections",1.0.0,1.0.15,MODERATE,CWE-400
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core",Microsoft.AspNetCore.All,2.1.0,2.1.15,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core",Microsoft.AspNetCore.App,2.1.0,2.1.15,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core",Microsoft.AspNetCore.App,3.0.0,3.0.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core",Microsoft.AspNetCore.App,3.1.0,3.1.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.linux-arm",3.1.0,3.1.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.1.0,3.1.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.1.0,3.1.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.linux-x64",3.1.0,3.1.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.osx-x64",3.1.0,3.1.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.win-arm",3.1.0,3.1.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.win-x64",3.1.0,3.1.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core","Microsoft.AspNetCore.App.Runtime.win-x86",3.1.0,3.1.1,HIGH,CWE-119
+CVE-2020-0603,2022-05-24T17:06:16Z,"Remote code execution in ASP.NET Core","Microsoft.AspNetCore.Http.Connections",1.0.0,1.0.15,HIGH,CWE-119
+CVE-2020-0606,2022-05-24T17:06:16Z,"Remote code execution in Microsoft.WindowsDesktop.App.Ref","Microsoft.WindowsDesktop.App.Ref",3.0.1,3.0.2,HIGH,CWE-20
+CVE-2020-0606,2022-05-24T17:06:16Z,"Remote code execution in Microsoft.WindowsDesktop.App.Ref","Microsoft.WindowsDesktop.App.Ref",3.1.0,3.1.1,HIGH,CWE-20
+CVE-2020-0606,2022-05-24T17:06:16Z,"Remote code execution in Microsoft.WindowsDesktop.App.Ref","Microsoft.WindowsDesktop.App.Runtime.win-x64",3.0.0,3.0.2,HIGH,CWE-20
+CVE-2020-0606,2022-05-24T17:06:16Z,"Remote code execution in Microsoft.WindowsDesktop.App.Ref","Microsoft.WindowsDesktop.App.Runtime.win-x64",3.1.0,3.1.11,HIGH,CWE-20
+CVE-2020-0606,2022-05-24T17:06:16Z,"Remote code execution in Microsoft.WindowsDesktop.App.Ref","Microsoft.WindowsDesktop.App.Runtime.win-x86",3.0.0,3.0.2,HIGH,CWE-20
+CVE-2020-0606,2022-05-24T17:06:16Z,"Remote code execution in Microsoft.WindowsDesktop.App.Ref","Microsoft.WindowsDesktop.App.Runtime.win-x86",3.1.0,3.1.11,HIGH,CWE-20
+CVE-2020-0710,2022-05-24T17:08:29Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.16,HIGH,CWE-119;CWE-787
+CVE-2020-0711,2022-05-24T17:08:29Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.16,HIGH,CWE-119;CWE-787
+CVE-2020-0712,2022-05-24T17:08:29Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.16,HIGH,CWE-119;CWE-787
+CVE-2020-0713,2022-05-24T17:08:29Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.16,HIGH,CWE-119;CWE-787
+CVE-2020-0767,2022-05-24T17:08:34Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.16,HIGH,CWE-119
+CVE-2020-0768,2021-08-02T17:26:23Z,"Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0811,2022-05-24T17:10:58Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-119
+CVE-2020-0812,2022-05-24T17:10:58Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-119
+CVE-2020-0813,2022-05-24T22:28:59Z,"ChakraCore information disclosure vulnerability",Microsoft.ChakraCore,0,1.11.17,HIGH,
+CVE-2020-0823,2021-07-28T18:57:11Z,"Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0825,2021-07-28T18:57:02Z," Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0826,2021-07-28T18:58:03Z,"Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0827,2021-07-28T18:56:52Z,"Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0828,2021-07-28T18:58:22Z,"Out-of-bounds Write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0829,2021-07-28T18:57:39Z,"Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0830,2021-07-28T18:57:47Z,"Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0831,2021-07-28T18:58:14Z,"Out-of-bounds Write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0832,2021-07-28T18:57:27Z,"Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0833,2021-07-28T18:57:55Z," Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0848,2021-07-28T18:57:19Z,"Out-of-bounds write in ChakraCore",Microsoft.ChakraCore,0,1.11.17,HIGH,CWE-787
+CVE-2020-0969,2022-05-24T17:14:32Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.18,HIGH,CWE-119;CWE-787
+CVE-2020-0970,2022-05-24T17:14:32Z,"ChakraCore Remote Code Execution Vulnerability",Microsoft.ChakraCore,0,1.11.18,HIGH,CWE-787
+CVE-2020-1037,2022-05-24T17:18:23Z,"ChakraCore Remote Code Execution Vulnerability",Microsoft.ChakraCore,0,1.11.19,HIGH,CWE-787
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure",Microsoft.AspNetCore.App,0,2.1.22,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.App.Runtime.linux-arm",3.1.0,3.1.8,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.1.0,3.1.8,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.8,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.1.0,3.1.8,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.App.Runtime.linux-x64",3.1.0,3.1.8,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.App.Runtime.osx-x64",3.1.0,3.1.8,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.App.Runtime.win-arm",3.1.0,3.1.8,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.App.Runtime.win-arm64",3.1.5,3.1.8,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.App.Runtime.win-x64",3.1.0,3.1.8,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.App.Runtime.win-x86",3.1.0,3.1.8,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure","Microsoft.AspNetCore.Http",0,2.1.22,HIGH,
+CVE-2020-1045,2022-05-24T17:27:57Z,"Cookie parsing failure",Microsoft.Owin,0,4.1.1,HIGH,
+CVE-2020-1057,2021-08-02T17:28:53Z,"Remote code execution in ChakraCore",Microsoft.ChakraCore,0,1.11.22,HIGH,CWE-119;CWE-787
+CVE-2020-1065,2022-05-24T17:18:25Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.19,HIGH,CWE-119;CWE-787
+CVE-2020-1073,2022-05-24T17:19:47Z,"ChakraCore RCE Vulnerability",Microsoft.ChakraCore,0,1.11.20,HIGH,CWE-119;CWE-787
+CVE-2020-11005,2020-04-14T23:09:13Z,"Internal NCryptDecrypt method could be used externally from WindowsHello library.","HaemmerElectronics.SeppPenner.WindowsHello",0,1.0.4,MODERATE,CWE-288
+CVE-2020-11022,2020-04-29T22:18:55Z,"Potential XSS vulnerability in jQuery",jquery,1.2.0,3.5.0,MODERATE,CWE-79
+CVE-2020-11023,2020-04-29T22:19:14Z,"Potential XSS vulnerability in jQuery",jQuery,1.0.3,3.5.0,MODERATE,CWE-79
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability",Microsoft.NETCore.App,2.1.0,2.1.18,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",3.1.0,3.1.4,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",3.1.0,3.1.4,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.4,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",3.1.0,3.1.4,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",3.1.0,3.1.4,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",3.1.0,3.1.4,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.rhel.6-x64",3.1.0,3.1.4,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",3.1.0,3.1.4,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",3.1.0,3.1.4,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",3.1.0,3.1.4,HIGH,
+CVE-2020-1108,2022-05-24T17:18:28Z,".NET Core & .NET Framework Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",3.1.0,3.1.4,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability",Microsoft.NETCore.App,2.1.0,2.1.20,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",3.1.0,3.1.6,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",3.1.0,3.1.6,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.6,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",3.1.0,3.1.6,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",3.1.0,3.1.6,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",3.1.0,3.1.6,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.rhel.6-x64",3.1.0,3.1.6,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",3.1.0,3.1.6,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",3.1.0,3.1.6,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",3.1.0,3.1.6,HIGH,
+CVE-2020-1147,2022-05-24T17:22:57Z,".NET Framework, SharePoint Server, and Visual Studio Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",3.1.0,3.1.6,HIGH,
+CVE-2020-1161,2022-05-24T17:18:32Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",3.1.0,3.1.4,HIGH,CWE-20
+CVE-2020-1161,2022-05-24T17:18:32Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.1.0,3.1.4,HIGH,CWE-20
+CVE-2020-1161,2022-05-24T17:18:32Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.4,HIGH,CWE-20
+CVE-2020-1161,2022-05-24T17:18:32Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.1.0,3.1.4,HIGH,CWE-20
+CVE-2020-1161,2022-05-24T17:18:32Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",3.1.0,3.1.4,HIGH,CWE-20
+CVE-2020-1161,2022-05-24T17:18:32Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",3.1.0,3.1.4,HIGH,CWE-20
+CVE-2020-1161,2022-05-24T17:18:32Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",3.1.0,3.1.4,HIGH,CWE-20
+CVE-2020-1161,2022-05-24T17:18:32Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",3.1.0,3.1.4,HIGH,CWE-20
+CVE-2020-1161,2022-05-24T17:18:32Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",3.1.0,3.1.4,HIGH,CWE-20
+CVE-2020-1172,2021-08-02T17:29:01Z,"Remote code execution in ChakraCore",Microsoft.ChakraCore,0,1.11.22,HIGH,CWE-787
+CVE-2020-1180,2021-08-02T17:29:09Z,"Remote code execution in ChakraCore",Microsoft.ChakraCore,0,1.11.22,HIGH,CWE-787
+CVE-2020-1469,2022-04-08T18:11:51Z,"Infinite loop in .Net Bond",Bond.Core.CSharp,3.0.0,9.0.1,HIGH,CWE-434;CWE-835
+CVE-2020-15522,2021-08-13T15:22:31Z,"Timing based private key exposure in Bouncy Castle",BouncyCastle,0,1.8.7,MODERATE,CWE-203;CWE-362
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability",Microsoft.AspNetCore.All,2.1.0,2.1.21,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability",Microsoft.AspNetCore.App,2.1.0,2.1.21,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",3.1.0,3.1.7,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.1.0,3.1.7,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.7,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.1.0,3.1.7,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",3.1.0,3.1.7,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",3.1.0,3.1.7,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",3.1.0,3.1.7,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",3.1.0,3.1.7,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",3.1.0,3.1.7,HIGH,CWE-20
+CVE-2020-1597,2022-05-24T17:26:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",3.1.0,3.1.7,HIGH,CWE-20
+CVE-2020-15999,2020-10-27T19:47:38Z,"Heap buffer overflow in CefSharp",CefSharp.Common,0,85.3.130,MODERATE,CWE-119;CWE-787
+CVE-2020-15999,2020-10-27T19:47:38Z,"Heap buffer overflow in CefSharp",CefSharp.WinForms,0,85.3.130,MODERATE,CWE-119;CWE-787
+CVE-2020-15999,2020-10-27T19:47:38Z,"Heap buffer overflow in CefSharp",CefSharp.Wpf,0,85.3.130,MODERATE,CWE-119;CWE-787
+CVE-2020-15999,2020-10-27T19:47:38Z,"Heap buffer overflow in CefSharp",CefSharp.Wpf.HwndHost,0,85.3.130,MODERATE,CWE-119;CWE-787
+CVE-2020-16009,2020-12-02T18:28:47Z,"Inappropriate implementation in V8",CefSharp.Common,0,86.0.241,HIGH,CWE-787
+CVE-2020-16009,2020-12-02T18:28:47Z,"Inappropriate implementation in V8",CefSharp.WinForms,0,86.0.241,HIGH,CWE-787
+CVE-2020-16009,2020-12-02T18:28:47Z,"Inappropriate implementation in V8",CefSharp.Wpf,0,86.0.241,HIGH,CWE-787
+CVE-2020-16009,2020-12-02T18:28:47Z,"Inappropriate implementation in V8",CefSharp.Wpf.HwndHost,0,86.0.241,HIGH,CWE-787
+CVE-2020-16013,2020-11-27T20:12:55Z,"Inappropriate implementation in V8 in CefSharp",CefSharp.Common,0,86.0.241,HIGH,CWE-119;CWE-787
+CVE-2020-16013,2020-11-27T20:12:55Z,"Inappropriate implementation in V8 in CefSharp",CefSharp.WinForms,0,86.0.241,HIGH,CWE-119;CWE-787
+CVE-2020-16013,2020-11-27T20:12:55Z,"Inappropriate implementation in V8 in CefSharp",CefSharp.Wpf,0,86.0.241,HIGH,CWE-119;CWE-787
+CVE-2020-16013,2020-11-27T20:12:55Z,"Inappropriate implementation in V8 in CefSharp",CefSharp.Wpf.HwndHost,0,86.0.241,HIGH,CWE-119;CWE-787
+CVE-2020-16017,2020-11-27T20:13:05Z,"Use after free in CefSharp",CefSharp.Common,0,86.0.241,HIGH,CWE-416
+CVE-2020-16017,2020-11-27T20:13:05Z,"Use after free in CefSharp",CefSharp.WinForms,0,86.0.241,HIGH,CWE-416
+CVE-2020-16017,2020-11-27T20:13:05Z,"Use after free in CefSharp",CefSharp.Wpf,0,86.0.241,HIGH,CWE-416
+CVE-2020-16017,2020-11-27T20:13:05Z,"Use after free in CefSharp",CefSharp.Wpf.HwndHost,0,86.0.241,HIGH,CWE-416
+CVE-2020-17048,2021-08-02T17:26:11Z,"Out-of-bounds Write in ChakraCore",Microsoft.ChakraCore,0,1.11.23,HIGH,CWE-787
+CVE-2020-17054,2021-08-02T17:25:58Z,"Out-of-bounds Write in ChakraCore",Microsoft.ChakraCore,0,1.11.23,HIGH,CWE-787
+CVE-2020-17131,2021-04-13T15:54:40Z,"Out-of-bounds Write in Chakra",Microsoft.ChakraCore,0,1.11.24,HIGH,CWE-787
+CVE-2020-20136,2022-05-24T17:36:17Z,"QuantConnect Lean vulnerable to insecure deserialization",QuantConnect.Common,2.3.0.0,,CRITICAL,CWE-502
+CVE-2020-23064,2023-06-26T21:30:58Z,"Duplicate Advisory: jQuery Cross Site Scripting vulnerability",jQuery,1.0.3,3.5.0,MODERATE,CWE-79
+CVE-2020-26293,2021-01-04T18:22:11Z,"XSS in HtmlSanitizer",HtmlSanitizer,0,5.0.372,LOW,CWE-74;CWE-79
+CVE-2020-27998,2021-08-02T17:28:16Z,"Missing Authorization in FastReport",FastReport.OpenSource,0,2020.4.0,CRITICAL,CWE-862
+CVE-2020-28042,2021-01-13T19:13:11Z,"Signature validation bypass in ServiceStack",ServiceStack,0,5.9.2,MODERATE,CWE-347
+CVE-2020-29454,2021-04-13T15:48:05Z,"Incorrect permission enforcement in UmbracoCms",UmbracoCms,0,8.10.0,MODERATE,CWE-732
+CVE-2020-29457,2021-11-19T20:19:53Z,"Improper Certificate Validation in OPCFoundation.NetStandard.Opc.Ua.Core","OPCFoundation.NetStandard.Opc.Ua.Core",0,1.4.365.10,MODERATE,CWE-295
+CVE-2020-36620,2022-12-21T21:30:15Z,"EnumStringValues vulnerable to Uncontrolled Resource Consumption",EnumStringValues,0,4.0.2,LOW,CWE-400;CWE-404
+CVE-2020-5186,2022-05-24T17:09:33Z,"DNN XSS Vulnerability",DotNetNuke.Core,0,,MODERATE,CWE-79
+CVE-2020-5187,2022-05-24T17:09:34Z,"DNN Path Traversal via Zip Slip",DotNetNuke.Core,0,9.5.0,HIGH,CWE-22
+CVE-2020-5188,2022-05-24T17:09:34Z,"DNN File Upload Vulnerability",DotNetNuke.Core,0,,MODERATE,CWE-434
+CVE-2020-5234,2020-01-31T17:59:20Z,"Untrusted data can lead to DoS attack due to hash collisions and stack overflow in MessagePack",MessagePack,0,1.9.11,MODERATE,CWE-121
+CVE-2020-5234,2020-01-31T17:59:20Z,"Untrusted data can lead to DoS attack due to hash collisions and stack overflow in MessagePack",MessagePack,2.0.0,2.1.90,MODERATE,CWE-121
+CVE-2020-5234,2020-01-31T17:59:20Z,"Untrusted data can lead to DoS attack due to hash collisions and stack overflow in MessagePack","MessagePack.ImmutableCollection",0,1.9.11,MODERATE,CWE-121
+CVE-2020-5234,2020-01-31T17:59:20Z,"Untrusted data can lead to DoS attack due to hash collisions and stack overflow in MessagePack","MessagePack.ImmutableCollection",2.0.0,2.1.90,MODERATE,CWE-121
+CVE-2020-5234,2020-01-31T17:59:20Z,"Untrusted data can lead to DoS attack due to hash collisions and stack overflow in MessagePack","MessagePack.ReactiveProperty",0,1.9.11,MODERATE,CWE-121
+CVE-2020-5234,2020-01-31T17:59:20Z,"Untrusted data can lead to DoS attack due to hash collisions and stack overflow in MessagePack","MessagePack.ReactiveProperty",2.0.0,2.1.90,MODERATE,CWE-121
+CVE-2020-5234,2020-01-31T17:59:20Z,"Untrusted data can lead to DoS attack due to hash collisions and stack overflow in MessagePack",MessagePack.UnityShims,0,1.9.11,MODERATE,CWE-121
+CVE-2020-5234,2020-01-31T17:59:20Z,"Untrusted data can lead to DoS attack due to hash collisions and stack overflow in MessagePack",MessagePack.UnityShims,2.0.0,2.1.90,MODERATE,CWE-121
+CVE-2020-5261,2020-03-25T16:52:49Z,"Missing Token Replay Detection in Saml2 Authentication services for ASP.NET",Sustainsys.Saml2,2.0.0,2.5.0,HIGH,CWE-294
+CVE-2020-5268,2020-04-22T20:59:37Z,"Subject Confirmation Method not validated in Saml2 Authentication Services for ASP.NET",Sustainsys.Saml2,0,1.0.2,MODERATE,CWE-303
+CVE-2020-5268,2020-04-22T20:59:37Z,"Subject Confirmation Method not validated in Saml2 Authentication Services for ASP.NET",Sustainsys.Saml2,2.0.0,2.7.0,MODERATE,CWE-303
+CVE-2020-5809,2022-05-24T17:37:51Z,"Umbraco CMS vulnerable to stored XSS",UmbracoCms.Core,0,,MODERATE,CWE-79
+CVE-2020-5811,2021-04-13T15:51:33Z,"Authenticated path traversal in Umbraco CMS",UmbracoCms,0,8.9.2,MODERATE,CWE-22
+CVE-2020-7210,2022-05-24T17:07:13Z,"Umbraco CMS vulnerable to CSRF",UmbracoCMS.Core,0,8.5.0,MODERATE,CWE-352
+CVE-2020-7656,2020-05-20T16:18:01Z,"Cross-Site Scripting in jquery",jQuery,0,1.9.0,MODERATE,CWE-79
+CVE-2020-7685,2020-07-29T17:29:51Z,"Insecure defaults in UmbracoForms",UmbracoForms,0,,HIGH,CWE-1188
+CVE-2020-7791,2020-12-14T19:50:22Z,"Denial of Service in i18n",i18n,0,2.1.15,HIGH,CWE-20;CWE-400
+CVE-2020-8867,2021-08-02T17:35:42Z,"Insufficient Session Expiration and TOCTOU Race Condition in OPC FOundation UA .Net Standard","OPCFoundation.NetStandard.Opc.Ua",0,1.4.359.31,MODERATE,CWE-367;CWE-613
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-arm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.browser-wasm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.ios-arm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.ios-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.iossimulator-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.iossimulator-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.iossimulator-x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.maccatalyst-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.maccatalyst-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvos-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvossimulator-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvossimulator-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x86.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.browser-wasm",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-arm",3.0.0,3.1.23,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-arm",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-arm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-arm64",3.0.0,3.1.23,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-arm64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-musl-arm",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-musl-arm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-musl-arm64",3.0.0,3.1.23,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-musl-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-musl-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-x64",3.0.0,3.1.23,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.linux-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-arm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-arm.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-arm.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-arm.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-x64.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-x64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-x64.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-x86.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-x86.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.android-x86.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.browser-wasm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.browser-wasm.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.browser-wasm.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.browser-wasm.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.ios-arm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.ios-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.ios-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.ios-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.ios-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.ios-arm.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.ios-arm.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.linux-arm",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.linux-arm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.linux-arm64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.linux-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.linux-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.linux-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-arm64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.osx-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.osx-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-arm64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.osx-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.LLVM.osx-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.osx-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.osx-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.osx-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvos-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvos-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvos-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvos-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64.Msi.arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64.Msi.x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64.Msi.x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.win-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.Mono.win-x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.osx-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.osx-x64",3.0.0,3.1.23,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.osx-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.osx-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-arm",3.0.0,3.1.23,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-arm",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-arm",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-arm64",3.0.0,3.1.23,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-arm64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-arm64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-x64",3.0.0,3.1.23,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-x64",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-x64",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-x86",3.0.0,3.1.23,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-x86",5.0.0,5.0.15,MODERATE,CWE-120
+CVE-2020-8927,2022-05-24T17:28:21Z,"Integer overflow in the bundled Brotli C library","Microsoft.NETCore.App.Runtime.win-x86",6.0.0,6.0.3,MODERATE,CWE-120
+CVE-2020-9471,2022-05-24T17:11:40Z,"Umbraco CMS Authenticated File Upload",UmbracoCMS.Core,0,,HIGH,CWE-434
+CVE-2020-9472,2021-08-02T17:38:56Z,"Unrestricted Upload of File with Dangerous Type in Umbraco CMS",UmbracoCms,0,8.5.4,MODERATE,CWE-434
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core",Microsoft.NETCore.App,2.1.0,2.1.25,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.linux-arm",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.linux-arm64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.linux-musl-arm64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.linux-musl-x64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.linux-x64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.osx-x64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.rhel.6-x64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.win-arm",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.win-arm64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.win-x64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Host.win-x86",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.android-arm",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.android-arm64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.android-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.android-x86",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.browser-wasm",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.ios-arm",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.ios-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.ios-x86",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-arm",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-arm",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-arm64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-arm64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-musl-arm",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-musl-x64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-musl-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-x64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.linux-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.linux-arm",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.linux-arm64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.linux-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-arm64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.osx-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-arm64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.LLVM.osx-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.Mono.osx-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.osx-x64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.osx-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.rhel.6-x64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.tvos-arm64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.tvos-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.win-arm",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.win-arm",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.win-arm64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.win-arm64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.win-x64",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.win-x64",5.0.0,5.0.3,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.win-x86",3.1.0,3.1.12,MODERATE,
+CVE-2021-1721,2022-05-24T17:43:10Z,"Denial of service in .NET core","Microsoft.NETCore.App.Runtime.win-x86",5.0.0,5.0.3,MODERATE,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",3.1.0,3.1.11,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",5.0.0,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.1.0,3.1.11,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",5.0.0,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",5.0.1,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.11,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.1.0,3.1.11,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",5.0.0,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",3.1.0,3.1.11,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",5.0.0,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",3.1.0,3.1.11,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",5.0.0,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",3.1.0,3.1.11,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",5.0.0,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",3.1.0,3.1.11,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",5.0.0,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",3.1.0,3.1.11,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",5.0.0,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",3.1.0,3.1.11,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",5.0.0,5.0.2,HIGH,
+CVE-2021-1723,2022-05-24T17:38:51Z,"ASP.NET Core and Visual Studio Denial of Service Vulnerability","Microsoft.AspNetCore.Server.Kestrel.Core",0,2.1.25,HIGH,
+CVE-2021-20331,2022-05-24T19:02:24Z,"MongoDB C# Driver Risk of Exposing Authentication Data via Command Listener",mongodb.driver,2.11.0,2.12.2,MODERATE,CWE-200
+CVE-2021-21252,2021-01-13T18:21:54Z,"Regular Expression Denial of Service in jquery-validation",jQuery.Validation,0,1.19.3,HIGH,CWE-400
+CVE-2021-22143,2023-11-22T03:30:19Z,"Exposure of Sensitive Information in Elastic APM .NET Agent",Elastic.Apm,0,1.10.0,LOW,CWE-200;CWE-532
+CVE-2021-22570,2022-01-27T00:01:15Z,"NULL Pointer Dereference in Protocol Buffers",Google.Protobuf,0,3.15.0,HIGH,CWE-476
+CVE-2021-23407,2021-08-02T17:30:27Z,"Path Traversal in elFinder.Net.Core",elFinder.Net.Core,0,1.2.4,HIGH,CWE-22
+CVE-2021-23415,2021-08-09T20:42:13Z,"Directory Traversal in elFinder.AspNet",elFinder.AspNet,0,1.1.1,HIGH,CWE-22
+CVE-2021-23427,2021-09-02T22:05:17Z,"Imporoper path validation in elFinder.NetCore",elFinder.NetCore,0,,CRITICAL,CWE-20
+CVE-2021-23428,2021-09-02T22:05:26Z,"Path traversal in elFinder.NetCore",elFinder.NetCore,0,,HIGH,CWE-20;CWE-22
+CVE-2021-23440,2021-09-13T20:09:36Z,"Prototype Pollution in set-value",set-value-nuget,0,2.0.0,HIGH,CWE-1321;CWE-843
+CVE-2021-23758,2021-12-16T15:27:55Z,"Remote Code Execution in AjaxNetProfessional",AjaxNetProfessional,0,21.11.29.1,CRITICAL,CWE-502
+CVE-2021-24112,2022-05-24T17:43:19Z,".NET Core Remote Code Execution Vulnerability",System.Drawing.Common,4.0.0,4.7.2,CRITICAL,
+CVE-2021-24112,2022-05-24T17:43:19Z,".NET Core Remote Code Execution Vulnerability",System.Drawing.Common,5.0.0,5.0.3,CRITICAL,
+CVE-2021-25976,2021-11-17T23:42:40Z,"Cross-Site Request Forgery in PiranhaCMS",Piranha,4.0.0-alpha1,10.0-alpha1,HIGH,CWE-352
+CVE-2021-25977,2021-10-27T18:53:03Z,"Cross-site Scripting in PiranhaCMS",Piranha,7.0.0,9.2.0,MODERATE,CWE-79
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-arm",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-arm64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-arm64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.osx-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-arm64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.osx-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.Mono.osx-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.rhel.6-x64",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",5.0.0,5.0.9,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",3.1.0,3.1.18,HIGH,
+CVE-2021-26423,2022-10-25T17:33:12Z,".NET Core Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",5.0.0,5.0.9,HIGH,
+CVE-2021-26701,2021-04-21T19:38:01Z,".NET Core Remote Code Execution Vulnerability","System.Text.Encodings.Web",4.0.0,4.5.1,CRITICAL,
+CVE-2021-26701,2021-04-21T19:38:01Z,".NET Core Remote Code Execution Vulnerability","System.Text.Encodings.Web",4.6.0,4.7.2,CRITICAL,
+CVE-2021-26701,2021-04-21T19:38:01Z,".NET Core Remote Code Execution Vulnerability","System.Text.Encodings.Web",5.0.0,5.0.1,CRITICAL,
+CVE-2021-27293,2021-07-14T19:10:01Z,"Incorrect Regular Expression in RestSharp",RestSharp,0,106.11.8-alpha.0.13,HIGH,CWE-185;CWE-697
+CVE-2021-29508,2021-05-19T23:02:38Z,"Insecure deserialization in Wire",Wire,0,,CRITICAL,CWE-502
+CVE-2021-31819,2021-09-23T23:17:07Z,"Remote Code Execution in Halibut",Halibut,0,4.4.7,CRITICAL,CWE-502
+CVE-2021-31957,2021-10-06T00:23:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.NETCore.App.Ref",0,3.1.16,HIGH,
+CVE-2021-31957,2021-10-06T00:23:01Z,"ASP.NET Core Denial of Service Vulnerability","Microsoft.NETCore.App.Ref",5.0.0,5.0.7,HIGH,
+CVE-2021-32840,2022-02-01T16:22:50Z,"Path Traversal in SharpZipLib",SharpZipLib,0,1.3.3,HIGH,CWE-22
+CVE-2021-32841,2022-02-01T16:22:57Z,"Path Traversal in SharpZipLib",SharpZipLib,1.3.0,1.3.3,MODERATE,CWE-22
+CVE-2021-32842,2022-02-01T16:23:00Z,"Path Traversal in SharpZipLib",SharpZipLib,1.0.0,1.3.3,MODERATE,CWE-22
+CVE-2021-33318,2022-05-17T00:00:35Z,"Improper Input Validation in IpMatcher",IpMatcher,0,1.0.4.2,CRITICAL,CWE-20;CWE-704
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability",Microsoft.NETCore.App,2.1.0,2.1.29,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-arm",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-arm64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-arm64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.osx-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-arm64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.osx-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.Mono.osx-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.rhel.6-x64",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",5.0.0,5.0.9,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",3.1.0,3.1.18,MODERATE,
+CVE-2021-34485,2022-10-20T21:34:09Z,".NET Core Information Disclosure Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",5.0.0,5.0.9,MODERATE,
+CVE-2021-34532,2021-08-25T14:45:28Z,"ASP.NET Core Information Disclosure Vulnerability","Microsoft.AspNetCore.Authentication.JwtBearer",2.1.0,2.1.29,MODERATE,
+CVE-2021-34532,2021-08-25T14:45:28Z,"ASP.NET Core Information Disclosure Vulnerability","Microsoft.AspNetCore.Authentication.JwtBearer",3.0.0,3.1.18,MODERATE,
+CVE-2021-34532,2021-08-25T14:45:28Z,"ASP.NET Core Information Disclosure Vulnerability","Microsoft.AspNetCore.Authentication.JwtBearer",5.0.0,5.0.9,MODERATE,
+CVE-2021-39208,2021-09-20T19:53:42Z,"Partial path traversal in sharpcompress",SharpCompress,0,0.29,MODERATE,CWE-22
+CVE-2021-41182,2021-10-26T14:55:02Z,"XSS in the `altField` option of the Datepicker widget in jquery-ui",jQuery.UI.Combined,0,1.13.0,MODERATE,CWE-79
+CVE-2021-41183,2021-10-26T14:55:21Z,"XSS in `*Text` options of the Datepicker widget in jquery-ui",jQuery.UI.Combined,0,1.13.0,MODERATE,CWE-79
+CVE-2021-41184,2021-10-26T14:55:12Z,"XSS in the `of` option of the `.position()` util in jquery-ui",jQuery.UI.Combined,0,1.13.0,MODERATE,CWE-79
+CVE-2021-41238,2021-11-03T17:30:59Z,"Missing Authorization with Default Settings in Dashboard UI",Hangfire.Core,1.7.25,1.7.26,HIGH,CWE-862
+CVE-2021-41355,2021-10-12T17:49:25Z,"Credential Disclosure in System.DirectoryServices.Protocols","System.DirectoryServices.Protocols",0,5.0.1,MODERATE,CWE-200
+CVE-2021-42279,2022-05-24T19:20:22Z,"Chakra Scripting Engine and ChakraCore Vulnerable to Memory Corruption",Microsoft.ChakraCore,0,,HIGH,CWE-787
+CVE-2021-4248,2022-12-18T12:30:20Z,"DNS NuGet package uses insufficiently random values",DNS,0,7.0.0,CRITICAL,CWE-330
+CVE-2021-42655,2022-05-25T00:00:37Z,"SQL injection in SiteServer CMS",SSCMS,0,,HIGH,CWE-89
+CVE-2021-42656,2022-05-25T00:00:37Z,"Cross site scripting in SiteServer CMS",SSCMS,0,,MODERATE,CWE-79
+CVE-2021-43045,2022-01-08T00:39:20Z,"Allocation of Resources Without Limits or Throttling in Apache Avro",Apache.Avro,0,1.11.0,HIGH,CWE-770
+CVE-2021-43306,2022-06-03T00:00:59Z,"Regular expression denial of service in jquery-validation",jQuery.Validation,0,1.19.4,LOW,CWE-1333
+CVE-2021-43569,2021-11-10T20:58:03Z,"Improper Verification of Cryptographic Signature in starkbank-ecdsa",starkbank-ecdsa,0,1.3.2,CRITICAL,CWE-347
+CVE-2021-43853,2022-01-06T18:32:24Z,"AjaxNetProfessional deserializes arbitrary JavaScript objects",AjaxNetProfessional,0,21.12.22.1,HIGH,CWE-502;CWE-79
+CVE-2021-44150,2021-11-29T18:09:08Z,"Use of Sha-1 in tusdotnet",tusdotnet,0,,LOW,CWE-327
+CVE-2021-46703,2022-03-07T00:00:41Z,"Code injection in RazorEngine",RazorEngine,0,,MODERATE,
+CVE-2022-0159,2022-01-21T23:57:49Z,"orchardcore is vulnerable to Cross-site Scripting",OrchardCore,0,1.2.1,MODERATE,CWE-79
+CVE-2022-0274,2022-01-21T23:08:50Z,"Cross-site Scripting OrchardCore.Application.Cms.Targets","OrchardCore.Application.Cms.Targets",0,1.2.2,MODERATE,CWE-79
+CVE-2022-0609,2022-02-22T21:51:19Z,"Use after free in Animation",CefSharp.Common,0,98.1.210,HIGH,CWE-416
+CVE-2022-0609,2022-02-22T21:51:19Z,"Use after free in Animation",CefSharp.Common.NETCore,0,98.1.210,HIGH,CWE-416
+CVE-2022-0609,2022-02-22T21:51:19Z,"Use after free in Animation",CefSharp.OffScreen,0,98.1.210,HIGH,CWE-416
+CVE-2022-0609,2022-02-22T21:51:19Z,"Use after free in Animation","CefSharp.OffScreen.NETCore",0,98.1.210,HIGH,CWE-416
+CVE-2022-0609,2022-02-22T21:51:19Z,"Use after free in Animation",CefSharp.WinForms,0,98.1.210,HIGH,CWE-416
+CVE-2022-0609,2022-02-22T21:51:19Z,"Use after free in Animation","CefSharp.WinForms.NETCore",0,98.1.210,HIGH,CWE-416
+CVE-2022-0609,2022-02-22T21:51:19Z,"Use after free in Animation",CefSharp.Wpf,0,98.1.210,HIGH,CWE-416
+CVE-2022-0609,2022-02-22T21:51:19Z,"Use after free in Animation",CefSharp.Wpf.HwndHost,0,98.1.210,HIGH,CWE-416
+CVE-2022-0609,2022-02-22T21:51:19Z,"Use after free in Animation",CefSharp.Wpf.NETCore,0,98.1.210,HIGH,CWE-416
+CVE-2022-0749,2022-03-18T00:01:10Z,"Deserialization of Untrusted Data in SinGooCMS.Utility",SinGooCMS.Utility,0,,CRITICAL,CWE-502
+CVE-2022-21167,2022-05-03T00:00:46Z,"Code Injection in Masuit.Tools.Core",Masuit.Tools.Core,0,,HIGH,CWE-94
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",6.0.0,6.0.2,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",5.0.0,5.0.14,HIGH,
+CVE-2022-21986,2022-10-21T20:29:04Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",6.0.0,6.0.2,HIGH,
+CVE-2022-22690,2022-01-21T23:34:24Z,"Umbraco ApplicationURL Overwrite",Umbraco.Cms.Core,0,9.2.0,HIGH,CWE-444
+CVE-2022-22691,2022-01-21T23:34:27Z,"Umbraco Persistent Password Reset Poison",Umbraco.Cms.Core,0,9.2.0,HIGH,CWE-444;CWE-640
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",5.0.1,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-23267,2022-10-21T20:50:24Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-23395,2022-03-03T00:00:51Z,"Prototype Pollution in jquery.cookie",jquery.cookie,0,,MODERATE,CWE-1321
+CVE-2022-23494,2022-12-08T23:30:01Z,"Cross-site scripting vulnerability in TinyMCE alerts",TinyMCE,0,5.10.7,MODERATE,CWE-79
+CVE-2022-23494,2022-12-08T23:30:01Z,"Cross-site scripting vulnerability in TinyMCE alerts",TinyMCE,6.0.0,6.3.1,MODERATE,CWE-79
+CVE-2022-23535,2023-02-24T16:22:50Z,"LiteDB may deserialize bad JSON on object type using _type",LiteDB,0,5.0.13,CRITICAL,CWE-502
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",3.0.0,3.1.23,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.0.0,3.1.23,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.0.0,3.1.23,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.0.0,3.1.23,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",3.0.0,3.1.23,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",3.0.0,3.1.23,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",3.0.0,3.1.23,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",3.1.5,3.1.23,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",3.0.0,3.1.23,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",6.0.0,6.0.3,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",3.0.0,3.1.23,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",5.0.0,5.0.15,HIGH,
+CVE-2022-24464,2022-10-21T20:32:34Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",6.0.0,6.0.3,HIGH,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-arm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.android-x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.browser-wasm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.android-x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.ios-arm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.ios-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.iossimulator-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.iossimulator-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.iossimulator-x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.maccatalyst-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.maccatalyst-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvos-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvossimulator-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.tvossimulator-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-arm.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-x86.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",3.0.0,3.1.23,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",3.0.0,3.1.23,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",3.0.0,3.1.23,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",3.0.0,3.1.23,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",3.0.0,3.1.23,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-arm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-arm.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-arm.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-arm.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-x64.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-x64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-x64.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-x86.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-x86.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.android-x86.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.browser-wasm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.browser-wasm.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.browser-wasm.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.browser-wasm.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.ios-arm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.ios-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.ios-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.ios-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.ios-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.ios-arm.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.ios-arm.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.ios-arm.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-arm",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-arm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-arm64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.linux-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-arm64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.linux-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.osx-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.AOT.osx-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-arm64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.linux-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.osx-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.LLVM.osx-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.osx-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.osx-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.osx-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvos-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvos-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvos-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvos-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64.Msi.arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64.Msi.x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64.Msi.x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.win-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.Mono.win-x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",3.0.0,3.1.23,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",3.0.0,3.1.23,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",3.0.0,3.1.23,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",3.0.0,3.1.23,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",6.0.0,6.0.3,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",3.0.0,3.1.23,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",5.0.0,5.0.15,MODERATE,
+CVE-2022-24512,2022-10-18T21:46:08Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",6.0.0,6.0.3,MODERATE,
+CVE-2022-24785,2022-04-04T21:25:48Z,"Path Traversal: 'dir/../../filename' in moment.locale",Moment.js,0,2.29.2,HIGH,CWE-22;CWE-27
+CVE-2022-24789,2022-03-30T00:00:31Z,"Server side request forgery in C1 CMS",C1CMS.Assemblies,0,6.12.8122.18346,HIGH,CWE-918
+CVE-2022-24849,2022-04-22T20:39:47Z,"Exposure of Sensitive Information to an Unauthorized Actor in DisCatSharp",DisCatSharp,9.8.5,9.9.1,MODERATE,CWE-200
+CVE-2022-26907,2022-04-16T00:00:28Z,"Azure SDK for .NET Information Disclosure Vulnerability.","Microsoft.Rest.ClientRuntime",0,2.3.24,MODERATE,CWE-532
+CVE-2022-26924,2022-04-22T20:23:44Z,"YARP Denial of Service Vulnerability",Yarp.ReverseProxy,0,1.0.1,HIGH,
+CVE-2022-26924,2022-04-22T20:23:44Z,"YARP Denial of Service Vulnerability",Yarp.ReverseProxy,1.1.0-rc.1.22152.1,1.1.0-rc.1.22211.2,HIGH,
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",3.0.0,3.1.25,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",5.0.0,5.0.17,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",6.0.0,6.0.5,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability",Microsoft.Owin,0,4.2.2,HIGH,CWE-400
+CVE-2022-29117,2022-08-30T19:32:29Z," .NET Denial of Service Vulnerability","Microsoft.Owin.Security.Cookies",0,4.2.2,HIGH,CWE-400
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",6.0.0,6.0.5,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",6.0.0,6.0.5,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",6.0.0,6.0.5,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.5,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",6.0.0,6.0.5,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",6.0.0,6.0.5,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",6.0.0,6.0.5,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",6.0.0,6.0.5,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",6.0.0,6.0.5,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",6.0.0,6.0.5,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",3.0.0,3.1.25,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",5.0.0,5.0.17,HIGH,
+CVE-2022-29145,2022-08-30T19:35:52Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",6.0.0,6.0.5,HIGH,
+CVE-2022-2922,2022-10-01T00:00:25Z,"DNN vulnerable to Relative Path Traversal",DotNetNuke.Core,0,9.11.0,MODERATE,CWE-22;CWE-23
+CVE-2022-2922,2022-10-01T00:00:25Z,"DNN vulnerable to Relative Path Traversal",DotNetNuke.Web,0,9.11.0,MODERATE,CWE-22;CWE-23
+CVE-2022-29245,2022-06-01T19:50:15Z,"Weak private key generation in SSH.NET",SSH.NET,0,2020.0.2,MODERATE,CWE-330;CWE-338
+CVE-2022-29362,2022-05-26T00:01:31Z,"Cross-site Scripting in ZKEACMS",ZKEACMS.Publisher,0,,MODERATE,CWE-79
+CVE-2022-29862,2022-06-17T21:44:01Z,"Security Update for the OPC UA .NET Standard Stack","OPCFoundation.NetStandard.Opc.Ua.Core",0,1.4.368.58,HIGH,CWE-835
+CVE-2022-29863,2022-06-17T21:45:15Z,"Memory Allocation with Excessive Size Value in OPCFoundation.NetStandard.Opc.Ua.Core","OPCFoundation.NetStandard.Opc.Ua.Core",0,1.4.368.58,HIGH,CWE-789
+CVE-2022-29864,2022-06-17T21:44:58Z,"Uncontrolled Resource Consumption in OPCFoundation.NetStandard.Opc.Ua.Core","OPCFoundation.NetStandard.Opc.Ua.Core",0,1.4.368.58,HIGH,CWE-400
+CVE-2022-29865,2022-06-17T21:44:39Z,"Incorrect Implementation of Authentication Algorithm in OPCFoundation.NetStandard.Opc.Ua.Core","OPCFoundation.NetStandard.Opc.Ua.Core",0,1.4.368.58,HIGH,CWE-287
+CVE-2022-29866,2022-06-17T21:44:23Z,"Uncontrolled Resource Consumption in OPCFoundation.NetStandard.Opc.Ua.Core","OPCFoundation.NetStandard.Opc.Ua.Core",0,1.4.368.58,HIGH,CWE-400
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine,3.5.0,4.9.5,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine,5.0.0,5.2.1,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine,5.10.0,5.11.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine,5.3.0,5.7.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine,5.8.0,5.9.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine,6.0.0,6.0.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine,6.1.0,6.2.1,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine.XPlat,3.5.0,4.9.5,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine.XPlat,5.0.0,5.2.1,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine.XPlat,5.10.0,5.11.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine.XPlat,5.3.0,5.7.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine.XPlat,5.8.0,5.9.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine.XPlat,6.0.0,6.0.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.CommandLine.XPlat,6.1.0,6.2.1,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.Commands,3.5.0,4.9.5,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.Commands,5.0.0,5.2.1,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.Commands,5.10.0,5.11.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.Commands,5.3.0,5.7.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.Commands,5.8.0,5.9.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.Commands,6.0.0,6.0.2,MODERATE,
+CVE-2022-30184,2022-06-14T21:57:52Z,"Potential leak of NuGet.org API key",NuGet.Commands,6.1.0,6.2.1,MODERATE,
+CVE-2022-30187,2022-07-13T00:00:39Z,"Microsoft: CBC Padding Oracle in Azure Blob Storage Encryption Library",Azure.Storage.Blobs,0,12.13.0,MODERATE,CWE-668
+CVE-2022-30187,2022-07-13T00:00:39Z,"Microsoft: CBC Padding Oracle in Azure Blob Storage Encryption Library",Azure.Storage.Queues,0,12.11.0,MODERATE,CWE-668
+CVE-2022-31129,2022-07-06T18:38:49Z,"Moment.js vulnerable to Inefficient Regular Expression Complexity",Moment.js,2.18.0,2.29.4,HIGH,CWE-1333;CWE-400
+CVE-2022-31160,2022-07-18T17:07:36Z,"jQuery UI vulnerable to XSS when refreshing a checkboxradio with an HTML-like initial text label",jQuery.UI.Combined,0,1.13.2,MODERATE,CWE-79
+CVE-2022-32173,2022-10-04T00:00:20Z,"OrchardCore vulnerable to HTML injection",OrchardCore,1.0.0-rc1-11259,1.4.0,MODERATE,CWE-79
+CVE-2022-33916,2022-08-24T00:00:32Z,"Exposure of Sensitive Information in OPCFoundation.NetStandard.Opc.Ua.Server","OPCFoundation.NetStandard.Opc.Ua.Server",0,1.4.370.9,MODERATE,CWE-200
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",3.1.0,3.1.28,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",6.0.0,6.0.8,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","System.Security.Cryptography.Xml",0,4.7.1,MODERATE,
+CVE-2022-34716,2024-02-03T00:47:54Z,".NET Information Disclosure Vulnerability","System.Security.Cryptography.Xml",5.0.0,6.0.1,MODERATE,
+CVE-2022-35540,2022-08-19T00:00:16Z,"Use of Hard-coded Credentials in AgileConfig.Client",AgileConfig.Client,0,1.6.8,CRITICAL,CWE-798
+CVE-2022-35909,2022-08-20T00:00:39Z,"Incorrect Access Control and Cross Site Scripting in Jellyfin",Jellyfin.Common,0,10.8.0,HIGH,CWE-79
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",3.1.0,3.1.29,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.1.0,3.1.29,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.29,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.1.0,3.1.29,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",3.1.0,3.1.29,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",3.1.0,3.1.29,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",3.1.0,3.1.29,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",3.1.0,3.1.29,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",3.1.0,3.1.29,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",5.0.0,6.0.9,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",3.1.0,3.1.29,HIGH,
+CVE-2022-38013,2022-09-15T03:25:36Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",5.0.0,6.0.9,HIGH,
+CVE-2022-39256,2022-09-30T04:54:06Z,"Orckestra C1 CMS's deserialization of untrusted data allows for arbitrary code execution.",CompositeC1.Core,0,6.13,CRITICAL,CWE-502
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.CommandLine,4.6.0,4.9.6,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.CommandLine,5.0.0,5.7.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.CommandLine,5.10.0,5.11.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.CommandLine,5.8.0,5.9.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.CommandLine,6.0.0,6.0.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.CommandLine,6.1.0,6.2.2,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.CommandLine,6.3.0,6.3.1,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Commands,4.6.0,4.9.6,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Commands,5.0.0,5.7.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Commands,5.10.0,5.11.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Commands,5.8.0,5.9.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Commands,6.0.0,6.0.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Commands,6.1.0,6.2.2,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Commands,6.3.0,6.3.1,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Protocol,4.6.0,4.9.6,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Protocol,5.0.0,5.7.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Protocol,5.10.0,5.11.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Protocol,5.8.0,5.9.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Protocol,6.0.0,6.0.3,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Protocol,6.1.0,6.2.2,HIGH,
+CVE-2022-41032,2022-10-11T20:48:52Z,"NuGet Elevation of Privilege Vulnerability",NuGet.Protocol,6.3.0,6.3.1,HIGH,
+CVE-2022-41064,2022-11-08T23:00:22Z,".NET Information Disclosure Vulnerability",Microsoft.Data.SqlClient,0,1.1.4,MODERATE,
+CVE-2022-41064,2022-11-08T23:00:22Z,".NET Information Disclosure Vulnerability",Microsoft.Data.SqlClient,2.0.0,2.1.2,MODERATE,
+CVE-2022-41064,2022-11-08T23:00:22Z,".NET Information Disclosure Vulnerability",System.Data.SqlClient,0,4.8.5,MODERATE,
+CVE-2022-41089,2022-12-14T21:42:00Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-arm64",6.0.0,6.0.12,HIGH,CWE-94
+CVE-2022-41089,2022-12-14T21:42:00Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-arm64",7.0.0,7.0.1,HIGH,CWE-94
+CVE-2022-41089,2022-12-14T21:42:00Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x64",3.1.0,3.1.32,HIGH,CWE-94
+CVE-2022-41089,2022-12-14T21:42:00Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x64",6.0.0,6.0.12,HIGH,CWE-94
+CVE-2022-41089,2022-12-14T21:42:00Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x64",7.0.0,7.0.1,HIGH,CWE-94
+CVE-2022-41089,2022-12-14T21:42:00Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x86",3.1.0,3.1.32,HIGH,CWE-94
+CVE-2022-41089,2022-12-14T21:42:00Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x86",6.0.0,6.0.12,HIGH,CWE-94
+CVE-2022-41089,2022-12-14T21:42:00Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x86",7.0.0,7.0.1,HIGH,CWE-94
+CVE-2022-41954,2022-11-28T22:09:09Z,"Temporary File Information Disclosure vulnerability in MPXJ",net.sf.mpxj,0,10.14.1,LOW,CWE-200;CWE-668
+CVE-2022-41954,2022-11-28T22:09:09Z,"Temporary File Information Disclosure vulnerability in MPXJ",net.sf.mpxj-for-csharp,0,10.14.1,LOW,CWE-200;CWE-668
+CVE-2022-41954,2022-11-28T22:09:09Z,"Temporary File Information Disclosure vulnerability in MPXJ",net.sf.mpxj-for-vb,0,10.14.1,LOW,CWE-200;CWE-668
+CVE-2022-48282,2023-02-21T21:30:18Z,"MongoDB .NET/C# Driver vulnerable to Deserialization of Untrusted Data",MongoDB.Driver,0,2.19.0,HIGH,CWE-502
+CVE-2023-0493,2023-01-27T00:30:18Z,"Withdrawn Advisory: HTML injections in BTCPayServer",BTCPayServer.Client,0,1.7.5,HIGH,CWE-74;CWE-76
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21538,2023-01-10T22:43:38Z,".NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",6.0.0,6.0.13,HIGH,CWE-502
+CVE-2023-21808,2023-02-14T22:00:54Z,".NET Remote Code Execution Vulnerability ","Microsoft.NetCore.App.Runtime.win-arm",6.0.0,6.0.14,HIGH,CWE-416
+CVE-2023-21808,2023-02-14T22:00:54Z,".NET Remote Code Execution Vulnerability ","Microsoft.NetCore.App.Runtime.win-arm64",6.0.0,6.0.14,HIGH,CWE-416
+CVE-2023-21808,2023-02-14T22:00:54Z,".NET Remote Code Execution Vulnerability ","Microsoft.NetCore.App.Runtime.win-arm64",7.0.0,7.0.3,HIGH,CWE-416
+CVE-2023-21808,2023-02-14T22:00:54Z,".NET Remote Code Execution Vulnerability ","Microsoft.NetCore.App.Runtime.win-arm",7.0.0,7.0.3,HIGH,CWE-416
+CVE-2023-21808,2023-02-14T22:00:54Z,".NET Remote Code Execution Vulnerability ","Microsoft.NetCore.App.Runtime.win-x64",6.0.0,6.0.14,HIGH,CWE-416
+CVE-2023-21808,2023-02-14T22:00:54Z,".NET Remote Code Execution Vulnerability ","Microsoft.NetCore.App.Runtime.win-x64",7.0.0,7.0.3,HIGH,CWE-416
+CVE-2023-21808,2023-02-14T22:00:54Z,".NET Remote Code Execution Vulnerability ","Microsoft.NetCore.App.Runtime.win-x86",6.0.0,6.0.14,HIGH,CWE-416
+CVE-2023-21808,2023-02-14T22:00:54Z,".NET Remote Code Execution Vulnerability ","Microsoft.NetCore.App.Runtime.win-x86",7.0.0,7.0.3,HIGH,CWE-416
+CVE-2023-21893,2023-01-18T00:30:16Z,"Component takeover in Oracle Data Provider for .NET",Oracle.ManagedDataAccess,19.0.0,19.18.0,HIGH,
+CVE-2023-21893,2023-01-18T00:30:16Z,"Component takeover in Oracle Data Provider for .NET",Oracle.ManagedDataAccess,21.0.0,21.9.0,HIGH,
+CVE-2023-21893,2023-01-18T00:30:16Z,"Component takeover in Oracle Data Provider for .NET","Oracle.ManagedDataAccess.Core",2.19.0,2.19.180,HIGH,
+CVE-2023-21893,2023-01-18T00:30:16Z,"Component takeover in Oracle Data Provider for .NET","Oracle.ManagedDataAccess.Core",3.21.0,3.21.90,HIGH,
+CVE-2023-24895,2023-06-14T17:02:24Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-arm64",6.0.0,6.0.18,HIGH,
+CVE-2023-24895,2023-06-14T17:02:24Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-arm64",7.0.0,7.0.7,HIGH,
+CVE-2023-24895,2023-06-14T17:02:24Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x64",6.0.0,6.0.18,HIGH,
+CVE-2023-24895,2023-06-14T17:02:24Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x64",7.0.0,7.0.7,HIGH,
+CVE-2023-24895,2023-06-14T17:02:24Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x86",6.0.0,6.0.18,HIGH,
+CVE-2023-24895,2023-06-14T17:02:24Z,".NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x86",7.0.0,7.0.7,HIGH,
+CVE-2023-24897,2023-06-14T17:01:16Z,".NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-arm",6.0.0,6.0.18,HIGH,CWE-122
+CVE-2023-24897,2023-06-14T17:01:16Z,".NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-arm64",6.0.0,6.0.18,HIGH,CWE-122
+CVE-2023-24897,2023-06-14T17:01:16Z,".NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-arm64",7.0.0,7.0.7,HIGH,CWE-122
+CVE-2023-24897,2023-06-14T17:01:16Z,".NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-arm",7.0.0,7.0.7,HIGH,CWE-122
+CVE-2023-24897,2023-06-14T17:01:16Z,".NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-x64",6.0.0,6.0.18,HIGH,CWE-122
+CVE-2023-24897,2023-06-14T17:01:16Z,".NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-x64",7.0.0,7.0.7,HIGH,CWE-122
+CVE-2023-24897,2023-06-14T17:01:16Z,".NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-x86",6.0.0,6.0.18,HIGH,CWE-122
+CVE-2023-24897,2023-06-14T17:01:16Z,".NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-x86",7.0.0,7.0.7,HIGH,CWE-122
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",7.0.0,7.0.7,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",6.0.0,6.0.18,HIGH,
+CVE-2023-24936,2023-06-14T17:04:29Z,".NET Elevation of Privilege Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",7.0.0,7.0.7,HIGH,
+CVE-2023-26154,2023-12-06T06:30:20Z,"pubnub Insufficient Entropy vulnerability",Pubnub,0,6.19.0,MODERATE,CWE-331
+CVE-2023-27321,2023-05-05T02:19:39Z,"Uncontrolled Resource Consumption in OPC UA .NET Standard Reference Server","OPCFoundation.NetStandard.Opc.Ua.Server",0,1.4.371.86,HIGH,CWE-400
+CVE-2023-28260,2023-04-11T22:02:15Z,".NET Remote Code Execution vulnerability","Microsoft.NetCore.App.Runtime.win-arm",6.0.0,6.0.16,HIGH,
+CVE-2023-28260,2023-04-11T22:02:15Z,".NET Remote Code Execution vulnerability","Microsoft.NetCore.App.Runtime.win-arm64",6.0.0,6.0.16,HIGH,
+CVE-2023-28260,2023-04-11T22:02:15Z,".NET Remote Code Execution vulnerability","Microsoft.NetCore.App.Runtime.win-arm64",7.0.0,7.0.5,HIGH,
+CVE-2023-28260,2023-04-11T22:02:15Z,".NET Remote Code Execution vulnerability","Microsoft.NetCore.App.Runtime.win-arm",7.0.0,7.0.5,HIGH,
+CVE-2023-28260,2023-04-11T22:02:15Z,".NET Remote Code Execution vulnerability","Microsoft.NetCore.App.Runtime.win-x64",6.0.0,6.0.16,HIGH,
+CVE-2023-28260,2023-04-11T22:02:15Z,".NET Remote Code Execution vulnerability","Microsoft.NetCore.App.Runtime.win-x64",7.0.0,7.0.5,HIGH,
+CVE-2023-28260,2023-04-11T22:02:15Z,".NET Remote Code Execution vulnerability","Microsoft.NetCore.App.Runtime.win-x86",6.0.0,6.0.16,HIGH,
+CVE-2023-28260,2023-04-11T22:02:15Z,".NET Remote Code Execution vulnerability","Microsoft.NetCore.App.Runtime.win-x86",7.0.0,7.0.5,HIGH,
+CVE-2023-2862,2023-05-24T12:30:17Z,"SSCMS vulnerable to Cross Site Scripting",SSCMS,0,,MODERATE,CWE-79
+CVE-2023-28638,2023-03-27T22:23:43Z,"Snappier vulnerable to buffer overrun due to improper restriction of operations within the bounds of a memory buffer",Snappier,1.1.0,1.1.1,HIGH,CWE-119
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.win-arm",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.win-arm",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.win-x64",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.win-x64",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.win-x86",6.0.0,6.0.18,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.NETCore.App.Runtime.win-x86",7.0.0,7.0.7,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.Windows.Compatibility",6.0.0,6.0.6,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","Microsoft.Windows.Compatibility",7.0.0,7.0.3,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","System.Security.Cryptography.Pkcs",6.0.0,6.0.3,HIGH,CWE-400
+CVE-2023-29331,2023-06-14T17:08:54Z,".NET Denial of Service vulnerability","System.Security.Cryptography.Pkcs",7.0.0,7.0.2,HIGH,CWE-400
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.CommandLine,4.6.0,5.11.5,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.CommandLine,6.0.0,6.0.5,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.CommandLine,6.2.0,6.2.4,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.CommandLine,6.3.0,6.3.3,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.CommandLine,6.4.0,6.4.2,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.CommandLine,6.5.0,6.5.1,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.CommandLine,6.6.0,6.6.1,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Commands,4.6.0,5.11.5,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Commands,6.0.0,6.0.5,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Commands,6.2.0,6.2.4,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Commands,6.3.0,6.3.3,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Commands,6.4.0,6.4.2,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Commands,6.5.0,6.5.1,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Commands,6.6.0,6.6.1,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Common,4.6.0,5.11.5,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Common,6.0.0,6.0.5,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Common,6.2.0,6.2.4,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Common,6.3.0,6.3.3,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Common,6.4.0,6.4.2,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Common,6.5.0,6.5.1,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Common,6.6.0,6.6.1,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.PackageManagement,4.6.0,5.11.5,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.PackageManagement,6.0.0,6.0.5,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.PackageManagement,6.2.0,6.2.4,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.PackageManagement,6.3.0,6.3.3,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.PackageManagement,6.4.0,6.4.2,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.PackageManagement,6.5.0,6.5.1,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.PackageManagement,6.6.0,6.6.1,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Protocol,4.7.0,5.11.5,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Protocol,6.0.0,6.0.5,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Protocol,6.2.0,6.2.4,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Protocol,6.3.0,6.3.3,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Protocol,6.4.0,6.4.2,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Protocol,6.5.0,6.5.1,HIGH,CWE-367
+CVE-2023-29337,2023-06-14T16:44:21Z,"NuGet Client Remote Code Execution Vulnerability",NuGet.Protocol,6.6.0,6.6.1,HIGH,CWE-367
+CVE-2023-30626,2023-04-24T22:39:03Z,"Directory traversal + file write causing arbitrary code execution",Jellyfin.Controller,10.8.0,10.8.10,HIGH,CWE-22
+CVE-2023-31048,2023-05-05T02:19:11Z,"Exposure of Sensitive Information in OPC UA .NET Standard Reference Server","OPCFoundation.NetStandard.Opc.Ua.Core",0,1.4.371.86,MODERATE,CWE-200
+CVE-2023-31048,2023-05-05T02:19:11Z,"Exposure of Sensitive Information in OPC UA .NET Standard Reference Server","OPCFoundation.NetStandard.Opc.Ua.Server",0,1.4.371.86,MODERATE,CWE-200
+CVE-2023-31285,2023-04-27T03:30:23Z,"Cross Site Scripting (XSS) in Serenity",Serenity.Net.Core,0,6.7.0,MODERATE,CWE-79
+CVE-2023-31285,2023-04-27T03:30:23Z,"Cross Site Scripting (XSS) in Serenity",Serenity.Net.Services,0,6.7.0,MODERATE,CWE-79
+CVE-2023-31286,2023-04-27T03:30:23Z,"User account enumeration in Serenity",Serenity.Net.Core,0,6.7.0,MODERATE,CWE-209
+CVE-2023-31286,2023-04-27T03:30:23Z,"User account enumeration in Serenity",Serenity.Net.Web,0,6.7.0,MODERATE,CWE-209
+CVE-2023-31287,2023-04-27T03:30:23Z,"Insufficient token expiration in Serenity",Serenity.Net.Core,0,6.7.0,HIGH,CWE-640
+CVE-2023-31287,2023-04-27T03:30:23Z,"Insufficient token expiration in Serenity",Serenity.Net.Web,0,6.7.0,HIGH,CWE-640
+CVE-2023-32571,2023-06-22T21:30:49Z,"Dynamic Linq vulnerable to remote code execution",System.Linq.Dynamic.Core,1.0.7.10,1.3.0,CRITICAL,CWE-697
+CVE-2023-33126,2023-06-14T17:18:10Z,"Microsoft Security Advisory CVE-2023-33126: .NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-arm",6.0.0,6.0.18,HIGH,
+CVE-2023-33126,2023-06-14T17:18:10Z,"Microsoft Security Advisory CVE-2023-33126: .NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-arm64",6.0.0,6.0.18,HIGH,
+CVE-2023-33126,2023-06-14T17:18:10Z,"Microsoft Security Advisory CVE-2023-33126: .NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-arm64",7.0.0,7.0.7,HIGH,
+CVE-2023-33126,2023-06-14T17:18:10Z,"Microsoft Security Advisory CVE-2023-33126: .NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-arm",7.0.0,7.0.7,HIGH,
+CVE-2023-33126,2023-06-14T17:18:10Z,"Microsoft Security Advisory CVE-2023-33126: .NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-x64",6.0.0,6.0.18,HIGH,
+CVE-2023-33126,2023-06-14T17:18:10Z,"Microsoft Security Advisory CVE-2023-33126: .NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-x64",7.0.0,7.0.7,HIGH,
+CVE-2023-33126,2023-06-14T17:18:10Z,"Microsoft Security Advisory CVE-2023-33126: .NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-x86",6.0.0,6.0.18,HIGH,
+CVE-2023-33126,2023-06-14T17:18:10Z,"Microsoft Security Advisory CVE-2023-33126: .NET Remote Code Execution Vulnerability","Microsoft.NetCore.App.Runtime.win-x86",7.0.0,7.0.7,HIGH,
+CVE-2023-33127,2023-07-11T22:45:28Z,"Microsoft Security Advisory CVE-2023-33127: .NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-arm64",6.0.0,6.0.20,HIGH,CWE-1220
+CVE-2023-33127,2023-07-11T22:45:28Z,"Microsoft Security Advisory CVE-2023-33127: .NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-arm64",7.0.0,7.0.9,HIGH,CWE-1220
+CVE-2023-33127,2023-07-11T22:45:28Z,"Microsoft Security Advisory CVE-2023-33127: .NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x64",6.0.0,6.0.20,HIGH,CWE-1220
+CVE-2023-33127,2023-07-11T22:45:28Z,"Microsoft Security Advisory CVE-2023-33127: .NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x64",7.0.0,7.0.9,HIGH,CWE-1220
+CVE-2023-33127,2023-07-11T22:45:28Z,"Microsoft Security Advisory CVE-2023-33127: .NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x86",6.0.0,6.0.20,HIGH,CWE-1220
+CVE-2023-33127,2023-07-11T22:45:28Z,"Microsoft Security Advisory CVE-2023-33127: .NET Remote Code Execution Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x86",7.0.0,7.0.9,HIGH,CWE-1220
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33128,2023-06-14T17:17:02Z,".NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",7.0.0,7.0.7,HIGH,CWE-416
+CVE-2023-33141,2023-06-23T21:37:26Z,"YARP Denial of Service Vulnerability",Yarp.ReverseProxy,0,1.1.2,HIGH,CWE-400
+CVE-2023-33141,2023-06-23T21:37:26Z,"YARP Denial of Service Vulnerability",Yarp.ReverseProxy,2.0.0,2.0.1,HIGH,CWE-400
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",0,6.0.20,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",7.0.0,7.0.9,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.Identity",0,2.1.39,HIGH,CWE-362
+CVE-2023-33170,2023-07-11T22:45:20Z," Microsoft Security Advisory CVE-2023-33170: .NET Security Feature Bypass Vulnerability","Microsoft.AspNet.Identity.Owin",0,2.2.4,HIGH,CWE-362
+CVE-2023-34230,2023-06-09T22:40:23Z,"Snowflake Connector .Net Command Injection",Snowflake.Data,0,2.0.18,HIGH,CWE-77
+CVE-2023-35390,2023-08-09T13:15:38Z,".NET Remote Code Execution Vulnerability","Microsoft.NET.Build.Containers",0,7.0.307,HIGH,CWE-77
+CVE-2023-35391,2023-08-11T20:54:45Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.SignalR.Redis",0,1.0.40,HIGH,CWE-200
+CVE-2023-35391,2023-08-11T20:54:45Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.SignalR.StackExchangeRedis",6.0.0,6.0.21,HIGH,CWE-200
+CVE-2023-35391,2023-08-11T20:54:45Z,".NET Information Disclosure Vulnerability","Microsoft.AspNetCore.SignalR.StackExchangeRedis",7.0.0,7.0.10,HIGH,CWE-200
+CVE-2023-36049,2023-11-14T20:39:33Z,"Microsoft Security Advisory CVE-2023-36049: .NET Elevation of Privilege Vulnerability",System.Net.Requests,6.0.0,6.0.25,HIGH,CWE-20
+CVE-2023-36049,2023-11-14T20:39:33Z,"Microsoft Security Advisory CVE-2023-36049: .NET Elevation of Privilege Vulnerability",System.Net.Requests,7.0.0,7.0.14,HIGH,CWE-20
+CVE-2023-36049,2023-11-14T20:39:33Z,"Microsoft Security Advisory CVE-2023-36049: .NET Elevation of Privilege Vulnerability",System.Net.Requests,8.0.0-rc.2.23480.2,8.0.0,HIGH,CWE-20
+CVE-2023-36414,2023-10-10T18:31:33Z,"Azure Identity SDK Remote Code Execution Vulnerability",Azure.Identity,0,1.10.2,HIGH,CWE-77
+CVE-2023-36435,2023-10-10T22:23:28Z,"MsQuic Remote Denial of Service Vulnerability","Microsoft.Native.Quic.MsQuic.OpenSSL",0,2.2.3,HIGH,CWE-400;CWE-401
+CVE-2023-36435,2023-10-10T22:23:28Z,"MsQuic Remote Denial of Service Vulnerability","Microsoft.Native.Quic.MsQuic.Schannel",0,2.2.3,HIGH,CWE-400;CWE-401
+CVE-2023-36558,2023-11-14T20:36:55Z,"Microsoft Security Advisory CVE-2023-36558: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.Components",6.0.0,6.0.25,MODERATE,
+CVE-2023-36558,2023-11-14T20:36:55Z,"Microsoft Security Advisory CVE-2023-36558: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.Components",7.0.0,7.0.14,MODERATE,
+CVE-2023-36558,2023-11-14T20:36:55Z,"Microsoft Security Advisory CVE-2023-36558: .NET Security Feature Bypass Vulnerability","Microsoft.AspNetCore.Components",8.0.0-rc.2.23480.2,8.0.0,MODERATE,
+CVE-2023-36566,2023-10-10T18:31:33Z,"Microsoft Common Data Model SDK Denial of Service Vulnerability","Microsoft.CommonDataModel.ObjectModel",0,1.7.4,MODERATE,CWE-20
+CVE-2023-36792,2023-09-12T20:51:36Z," Microsoft Security Advisory CVE-2023-36792: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",6.0.0,6.0.22,HIGH,
+CVE-2023-36792,2023-09-12T20:51:36Z," Microsoft Security Advisory CVE-2023-36792: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",7.0.0,7.0.11,HIGH,
+CVE-2023-36792,2023-09-12T20:51:36Z," Microsoft Security Advisory CVE-2023-36792: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",6.0.0,6.0.22,HIGH,
+CVE-2023-36792,2023-09-12T20:51:36Z," Microsoft Security Advisory CVE-2023-36792: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",7.0.0,7.0.11,HIGH,
+CVE-2023-36792,2023-09-12T20:51:36Z," Microsoft Security Advisory CVE-2023-36792: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",6.0.0,6.0.22,HIGH,
+CVE-2023-36792,2023-09-12T20:51:36Z," Microsoft Security Advisory CVE-2023-36792: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",7.0.0,7.0.11,HIGH,
+CVE-2023-36793,2023-09-12T20:15:59Z,"Microsoft Security Advisory CVE-2023-36793: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",6.0.0,6.0.22,HIGH,
+CVE-2023-36793,2023-09-12T20:15:59Z,"Microsoft Security Advisory CVE-2023-36793: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",7.0.0,7.0.11,HIGH,
+CVE-2023-36793,2023-09-12T20:15:59Z,"Microsoft Security Advisory CVE-2023-36793: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",6.0.0,6.0.22,HIGH,
+CVE-2023-36793,2023-09-12T20:15:59Z,"Microsoft Security Advisory CVE-2023-36793: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",7.0.0,7.0.11,HIGH,
+CVE-2023-36793,2023-09-12T20:15:59Z,"Microsoft Security Advisory CVE-2023-36793: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",6.0.0,6.0.22,HIGH,
+CVE-2023-36793,2023-09-12T20:15:59Z,"Microsoft Security Advisory CVE-2023-36793: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",7.0.0,7.0.11,HIGH,
+CVE-2023-36794,2023-09-12T20:26:05Z,"Microsoft Security Advisory CVE-2023-36794: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",6.0.0,6.0.22,HIGH,
+CVE-2023-36794,2023-09-12T20:26:05Z,"Microsoft Security Advisory CVE-2023-36794: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",7.0.0,7.0.11,HIGH,
+CVE-2023-36794,2023-09-12T20:26:05Z,"Microsoft Security Advisory CVE-2023-36794: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",6.0.0,6.0.22,HIGH,
+CVE-2023-36794,2023-09-12T20:26:05Z,"Microsoft Security Advisory CVE-2023-36794: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",7.0.0,7.0.11,HIGH,
+CVE-2023-36794,2023-09-12T20:26:05Z,"Microsoft Security Advisory CVE-2023-36794: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",6.0.0,6.0.22,HIGH,
+CVE-2023-36794,2023-09-12T20:26:05Z,"Microsoft Security Advisory CVE-2023-36794: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",7.0.0,7.0.11,HIGH,
+CVE-2023-36796,2023-09-12T20:05:18Z,"Microsoft Security Advisory CVE-2023-36796: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",6.0.0,6.0.22,HIGH,
+CVE-2023-36796,2023-09-12T20:05:18Z,"Microsoft Security Advisory CVE-2023-36796: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",7.0.0,7.0.11,HIGH,
+CVE-2023-36796,2023-09-12T20:05:18Z,"Microsoft Security Advisory CVE-2023-36796: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",6.0.0,6.0.22,HIGH,
+CVE-2023-36796,2023-09-12T20:05:18Z,"Microsoft Security Advisory CVE-2023-36796: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",7.0.0,7.0.11,HIGH,
+CVE-2023-36796,2023-09-12T20:05:18Z,"Microsoft Security Advisory CVE-2023-36796: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",6.0.0,6.0.22,HIGH,
+CVE-2023-36796,2023-09-12T20:05:18Z,"Microsoft Security Advisory CVE-2023-36796: .NET Remote Code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",7.0.0,7.0.11,HIGH,
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",6.0.0,6.0.22,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",6.0.0,6.0.22,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",7.0.0,7.0.11,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",7.0.0,7.0.11,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",6.0.0,6.0.22,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.22,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",7.0.0,7.0.11,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",7.0.0,7.0.11,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",6.0.0,6.0.22,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",7.0.0,7.0.11,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",6.0.0,6.0.22,MODERATE,CWE-400
+CVE-2023-36799,2023-09-12T19:57:06Z,"Microsoft Security Advisory CVE-2023-36799: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",7.0.0,7.0.11,MODERATE,CWE-400
+CVE-2023-37267,2023-07-13T17:02:07Z,"Umbraco allows possible Admin-level access to backoffice without Auth under rare conditions","Umbraco.Cms.Infrastructure",11.0.0,11.4.2,HIGH,CWE-284
+CVE-2023-37267,2023-07-13T17:02:07Z,"Umbraco allows possible Admin-level access to backoffice without Auth under rare conditions","Umbraco.Cms.Infrastructure",12.0.0,12.0.1,HIGH,CWE-284
+CVE-2023-37267,2023-07-13T17:02:07Z,"Umbraco allows possible Admin-level access to backoffice without Auth under rare conditions","Umbraco.Cms.Infrastructure",9.0.0,10.6.1,HIGH,CWE-284
+CVE-2023-37267,2023-07-13T17:02:07Z,"Umbraco allows possible Admin-level access to backoffice without Auth under rare conditions","Umbraco.Cms.Web.BackOffice",11.0.0,11.4.2,HIGH,CWE-284
+CVE-2023-37267,2023-07-13T17:02:07Z,"Umbraco allows possible Admin-level access to backoffice without Auth under rare conditions","Umbraco.Cms.Web.BackOffice",12.0.0,12.0.1,HIGH,CWE-284
+CVE-2023-37267,2023-07-13T17:02:07Z,"Umbraco allows possible Admin-level access to backoffice without Auth under rare conditions","Umbraco.Cms.Web.BackOffice",9.0.0,10.6.1,HIGH,CWE-284
+CVE-2023-38171,2023-10-10T21:23:27Z,"Remote Denial of Service Vulnerability in Microsoft.Native.Quic.MsQuic.Schannel","Microsoft.Native.Quic.MsQuic.OpenSSL",0,2.2.3,HIGH,CWE-400;CWE-476
+CVE-2023-38171,2023-10-10T21:23:27Z,"Remote Denial of Service Vulnerability in Microsoft.Native.Quic.MsQuic.Schannel","Microsoft.Native.Quic.MsQuic.Schannel",0,2.2.3,HIGH,CWE-400;CWE-476
+CVE-2023-38178,2023-08-09T13:04:54Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",7.0.0,7.0.10,HIGH,CWE-400
+CVE-2023-38178,2023-08-09T13:04:54Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",7.0.0,7.0.10,HIGH,CWE-400
+CVE-2023-38178,2023-08-09T13:04:54Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",7.0.0,7.0.10,HIGH,CWE-400
+CVE-2023-38178,2023-08-09T13:04:54Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",7.0.0,7.0.10,HIGH,CWE-400
+CVE-2023-38178,2023-08-09T13:04:54Z,".NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-arm64",7.0.0,7.0.10,HIGH,CWE-400
+CVE-2023-38178,2023-08-09T13:04:54Z,".NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-arm",7.0.0,7.0.10,HIGH,CWE-400
+CVE-2023-38178,2023-08-09T13:04:54Z,".NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-x64",7.0.0,7.0.10,HIGH,CWE-400
+CVE-2023-38178,2023-08-09T13:04:54Z,".NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-x86",7.0.0,7.0.10,HIGH,CWE-400
+CVE-2023-38180,2023-08-09T12:56:43Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",6.0.0,6.0.21,HIGH,
+CVE-2023-38180,2023-08-09T12:56:43Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",7.0.0,7.0.10,HIGH,
+CVE-2023-38180,2023-08-09T12:56:43Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",6.0.0,6.0.21,HIGH,
+CVE-2023-38180,2023-08-09T12:56:43Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",7.0.0,7.0.10,HIGH,
+CVE-2023-38180,2023-08-09T12:56:43Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",6.0.0,6.0.21,HIGH,
+CVE-2023-38180,2023-08-09T12:56:43Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",7.0.0,7.0.10,HIGH,
+CVE-2023-38180,2023-08-09T12:56:43Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv",0,2.1.40,HIGH,
+CVE-2023-38180,2023-08-09T12:56:43Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv",6.0.0,6.0.21,HIGH,
+CVE-2023-38180,2023-08-09T12:56:43Z,".NET Denial of Service Vulnerability","Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets",0,2.1.40,HIGH,
+CVE-2023-38694,2023-12-13T13:17:37Z,"Possible injection of HTML into user invite mails",Umbraco.CMS,11.0.0,12.1.0,LOW,CWE-79
+CVE-2023-38694,2023-12-13T13:17:37Z,"Possible injection of HTML into user invite mails",Umbraco.CMS,8.0.0,8.18.10,LOW,CWE-79
+CVE-2023-38694,2023-12-13T13:17:37Z,"Possible injection of HTML into user invite mails",Umbraco.CMS,9.0.0,10.7.0,LOW,CWE-79
+CVE-2023-41890,2023-09-20T23:01:52Z,"Sustainsys.Saml2 Insufficient Identity Provider Issuer Validation",Sustainsys.Saml2,0,1.0.3,HIGH,CWE-289
+CVE-2023-41890,2023-09-20T23:01:52Z,"Sustainsys.Saml2 Insufficient Identity Provider Issuer Validation",Sustainsys.Saml2,2.0.0,2.9.2,HIGH,CWE-289
+CVE-2023-44390,2023-10-04T18:52:35Z,"HtmlSanitizer vulnerable to Cross-site Scripting in Foreign Content",HtmlSanitizer,0,8.0.723,MODERATE,CWE-79
+CVE-2023-44390,2023-10-04T18:52:35Z,"HtmlSanitizer vulnerable to Cross-site Scripting in Foreign Content",HtmlSanitizer,8.1.0-beta,8.1.722-beta,MODERATE,CWE-79
+CVE-2023-45814,2023-10-19T16:11:59Z,"Bunkum tokens cached in the AuthenticationService are susceptible to a use-after-free",Bunkum,4.0.0,4.2.1,MODERATE,CWE-772
+CVE-2023-45818,2023-10-19T16:36:29Z,"TinyMCE mXSS vulnerability in undo/redo, getContent API, resetContent API, and Autosave plugin",TinyMCE,0,5.10.8,MODERATE,CWE-79
+CVE-2023-45818,2023-10-19T16:36:29Z,"TinyMCE mXSS vulnerability in undo/redo, getContent API, resetContent API, and Autosave plugin",TinyMCE,6.0.0,6.7.1,MODERATE,CWE-79
+CVE-2023-45819,2023-10-19T16:42:57Z,"TinyMCE XSS vulnerability in notificationManager.open API",TinyMCE,0,5.10.8,MODERATE,CWE-79
+CVE-2023-45819,2023-10-19T16:42:57Z,"TinyMCE XSS vulnerability in notificationManager.open API",TinyMCE,6.0.0,6.7.1,MODERATE,CWE-79
+CVE-2023-48219,2023-11-15T18:32:34Z,"TinyMCE vulnerable to mutation Cross-site Scripting via special characters in unescaped text nodes",TinyMCE,0,5.10.9,MODERATE,CWE-79
+CVE-2023-48219,2023-11-15T18:32:34Z,"TinyMCE vulnerable to mutation Cross-site Scripting via special characters in unescaped text nodes",TinyMCE,6.0.0,6.7.3,MODERATE,CWE-79
+CVE-2023-48227,2023-12-13T13:21:51Z,"Backoffice User can bypass ""Publish"" restriction",Umbraco.CMS,11.0.0,12.3.0,LOW,CWE-863
+CVE-2023-48227,2023-12-13T13:21:51Z,"Backoffice User can bypass ""Publish"" restriction",Umbraco.CMS,8.0.0,8.18.10,LOW,CWE-863
+CVE-2023-48227,2023-12-13T13:21:51Z,"Backoffice User can bypass ""Publish"" restriction",Umbraco.CMS,9.0.0,10.8.0,LOW,CWE-863
+CVE-2023-48313,2023-12-13T13:24:06Z,"DOM-XSS on Backoffice login screen.",Umbraco.CMS,10.0.0,10.8.1,MODERATE,CWE-79
+CVE-2023-48313,2023-12-13T13:24:06Z,"DOM-XSS on Backoffice login screen.",Umbraco.CMS,11.0.0,12.3.4,MODERATE,CWE-79
+CVE-2023-4863,2023-09-12T15:30:20Z,"libwebp: OOB write in BuildHuffmanTable",magick.net-q16-anycpu,0,13.3.0,HIGH,CWE-787
+CVE-2023-4863,2023-09-12T15:30:20Z,"libwebp: OOB write in BuildHuffmanTable","magick.net-q16-hdri-anycpu",0,13.3.0,HIGH,CWE-787
+CVE-2023-4863,2023-09-12T15:30:20Z,"libwebp: OOB write in BuildHuffmanTable",magick.net-q16-x64,0,13.3.0,HIGH,CWE-787
+CVE-2023-4863,2023-09-12T15:30:20Z,"libwebp: OOB write in BuildHuffmanTable",magick.net-q8-anycpu,0,13.3.0,HIGH,CWE-787
+CVE-2023-4863,2023-09-12T15:30:20Z,"libwebp: OOB write in BuildHuffmanTable",magick.net-q8-openmp-x64,0,13.3.0,HIGH,CWE-787
+CVE-2023-4863,2023-09-12T15:30:20Z,"libwebp: OOB write in BuildHuffmanTable",magick.net-q8-x64,0,13.3.0,HIGH,CWE-787
+CVE-2023-4863,2023-09-12T15:30:20Z,"libwebp: OOB write in BuildHuffmanTable",SkiaSharp,2.0.0,2.88.6,HIGH,CWE-787
+CVE-2023-49089,2023-12-13T13:24:53Z,"Using the directory back payload (“/../”) in a package name allows placement of package in other folders.",Umbraco.CMS,11.0.0,12.3.4,LOW,CWE-22
+CVE-2023-49089,2023-12-13T13:24:53Z,"Using the directory back payload (“/../”) in a package name allows placement of package in other folders.",Umbraco.CMS,8.0.0,8.18.10,LOW,CWE-22
+CVE-2023-49089,2023-12-13T13:24:53Z,"Using the directory back payload (“/../”) in a package name allows placement of package in other folders.",Umbraco.CMS,9.0.0,10.8.1,LOW,CWE-22
+CVE-2023-49273,2023-12-13T13:25:38Z,"Privilege Escalation using Spoofing",Umbraco.CMS,11.0.0,12.3.4,MODERATE,CWE-863
+CVE-2023-49273,2023-12-13T13:25:38Z,"Privilege Escalation using Spoofing",Umbraco.CMS,8.0.0,8.18.10,MODERATE,CWE-863
+CVE-2023-49273,2023-12-13T13:25:38Z,"Privilege Escalation using Spoofing",Umbraco.CMS,9.0.0,10.8.1,MODERATE,CWE-863
+CVE-2023-49274,2023-12-13T13:26:34Z,"SMTP misconfiguration leading to ""Forgot Password"" exploit that leaks registered user email. ",Umbraco.CMS,11.0.0,12.3.4,LOW,CWE-200
+CVE-2023-49274,2023-12-13T13:26:34Z,"SMTP misconfiguration leading to ""Forgot Password"" exploit that leaks registered user email. ",Umbraco.CMS,8.0.0,8.18.10,LOW,CWE-200
+CVE-2023-49274,2023-12-13T13:26:34Z,"SMTP misconfiguration leading to ""Forgot Password"" exploit that leaks registered user email. ",Umbraco.CMS,9.0.0,10.8.1,LOW,CWE-200
+CVE-2023-49278,2023-12-13T13:27:06Z," Brute force exploit can be used to collect valid usernames",Umbraco.CMS,11.0.0,12.3.4,LOW,CWE-200
+CVE-2023-49278,2023-12-13T13:27:06Z," Brute force exploit can be used to collect valid usernames",Umbraco.CMS,8.0.0,8.18.10,LOW,CWE-200
+CVE-2023-49278,2023-12-13T13:27:06Z," Brute force exploit can be used to collect valid usernames",Umbraco.CMS,9.0.0,10.8.1,LOW,CWE-200
+CVE-2023-49279,2023-12-13T13:30:53Z,"Stored XSS via SVG File Upload",Umbraco.CMS,11.0.0,11.5.0,LOW,CWE-79
+CVE-2023-49279,2023-12-13T13:30:53Z,"Stored XSS via SVG File Upload",Umbraco.CMS,12.0.0,12.2.0,LOW,CWE-79
+CVE-2023-49279,2023-12-13T13:30:53Z,"Stored XSS via SVG File Upload",Umbraco.CMS,7.0.0,7.15.11,LOW,CWE-79
+CVE-2023-49279,2023-12-13T13:30:53Z,"Stored XSS via SVG File Upload",Umbraco.CMS,8.0.0,8.18.9,LOW,CWE-79
+CVE-2023-49279,2023-12-13T13:30:53Z,"Stored XSS via SVG File Upload",Umbraco.CMS,9.0.0,10.7.0,LOW,CWE-79
+CVE-2023-49289,2023-12-05T00:06:04Z,"Ajax Pro Cross-site Scripting",AjaxNetProfessional,0,21.12.22.1,MODERATE,CWE-79
+CVE-2023-51652,2024-01-02T16:38:28Z,"OWASP.AntiSamy mXSS when preserving comments",OWASP.AntiSamy,0,1.2.0,MODERATE,CWE-79
+CVE-2023-51662,2023-12-22T19:51:09Z,"Snowflake Connector .NET does not properly check the Certificate Revocation List (CRL)",Snowflake.Data,2.0.25,2.1.5,MODERATE,CWE-295
+CVE-2024-0056,2024-01-09T18:30:27Z,"Microsoft.Data.SqlClient and System.Data.SqlClient vulnerable to SQL Data Provider Security Feature Bypass ",Microsoft.Data.SqlClient,0,2.1.7,HIGH,CWE-319
+CVE-2024-0056,2024-01-09T18:30:27Z,"Microsoft.Data.SqlClient and System.Data.SqlClient vulnerable to SQL Data Provider Security Feature Bypass ",Microsoft.Data.SqlClient,3.0.0,3.1.5,HIGH,CWE-319
+CVE-2024-0056,2024-01-09T18:30:27Z,"Microsoft.Data.SqlClient and System.Data.SqlClient vulnerable to SQL Data Provider Security Feature Bypass ",Microsoft.Data.SqlClient,4.0.0,4.0.5,HIGH,CWE-319
+CVE-2024-0056,2024-01-09T18:30:27Z,"Microsoft.Data.SqlClient and System.Data.SqlClient vulnerable to SQL Data Provider Security Feature Bypass ",Microsoft.Data.SqlClient,5.0.0,5.1.3,HIGH,CWE-319
+CVE-2024-0056,2024-01-09T18:30:27Z,"Microsoft.Data.SqlClient and System.Data.SqlClient vulnerable to SQL Data Provider Security Feature Bypass ",System.Data.SqlClient,0,4.8.6,HIGH,CWE-319
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.CommandLine,4.6.0,5.11.6,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.CommandLine,6.0.0,6.0.6,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.CommandLine,6.3.0,6.3.4,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.CommandLine,6.4.0,6.4.3,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.CommandLine,6.6.0,6.6.2,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.CommandLine,6.7.0,6.7.1,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.CommandLine,6.8.0,6.8.1,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.Packaging,4.6.0,5.11.6,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.Packaging,6.0.0,6.0.6,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.Packaging,6.3.0,6.3.4,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.Packaging,6.4.0,6.4.3,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.Packaging,6.6.0,6.6.2,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.Packaging,6.7.0,6.7.1,CRITICAL,
+CVE-2024-0057,2024-02-13T21:18:10Z,"NuGet Client Security Feature Bypass Vulnerability ",NuGet.Packaging,6.8.0,6.8.1,CRITICAL,
+CVE-2024-21319,2024-01-09T19:35:02Z,"Microsoft ASP.NET Core project templates vulnerable to denial of service","Microsoft.IdentityModel.JsonWebTokens",0,5.7.0,MODERATE,CWE-400
+CVE-2024-21319,2024-01-09T19:35:02Z,"Microsoft ASP.NET Core project templates vulnerable to denial of service","Microsoft.IdentityModel.JsonWebTokens",6.5.0,6.34.0,MODERATE,CWE-400
+CVE-2024-21319,2024-01-09T19:35:02Z,"Microsoft ASP.NET Core project templates vulnerable to denial of service","Microsoft.IdentityModel.JsonWebTokens",7.0.0-preview,7.1.2,MODERATE,CWE-400
+CVE-2024-21319,2024-01-09T19:35:02Z,"Microsoft ASP.NET Core project templates vulnerable to denial of service","System.IdentityModel.Tokens.Jwt",0,5.7.0,MODERATE,CWE-400
+CVE-2024-21319,2024-01-09T19:35:02Z,"Microsoft ASP.NET Core project templates vulnerable to denial of service","System.IdentityModel.Tokens.Jwt",6.5.0,6.34.0,MODERATE,CWE-400
+CVE-2024-21319,2024-01-09T19:35:02Z,"Microsoft ASP.NET Core project templates vulnerable to denial of service","System.IdentityModel.Tokens.Jwt",7.0.0-preview,7.1.2,MODERATE,CWE-400
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",0,6.0.27,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",7.0.0,7.0.16,CRITICAL,
+CVE-2024-21386,2024-02-13T19:49:43Z,"Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",8.0.0,8.0.2,CRITICAL,
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",7.0.0-preview.1.22076.8,7.0.17,HIGH,CWE-400
+CVE-2024-21392,2024-03-12T20:07:59Z,"Microsoft Security Advisory CVE-2024-21392: .NET Denial of Service Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",8.0.0,8.0.3,HIGH,CWE-400
+CVE-2024-21409,2024-04-17T18:21:57Z,".NET Elevation of Privilege Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-arm64",0,6.0.29,HIGH,CWE-416
+CVE-2024-21409,2024-04-17T18:21:57Z,".NET Elevation of Privilege Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-arm64",7.0.0,7.0.18,HIGH,CWE-416
+CVE-2024-21409,2024-04-17T18:21:57Z,".NET Elevation of Privilege Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-arm64",8.0.0,8.0.4,HIGH,CWE-416
+CVE-2024-21409,2024-04-17T18:21:57Z,".NET Elevation of Privilege Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x64",0,6.0.29,HIGH,CWE-416
+CVE-2024-21409,2024-04-17T18:21:57Z,".NET Elevation of Privilege Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x64",7.0.0,7.0.18,HIGH,CWE-416
+CVE-2024-21409,2024-04-17T18:21:57Z,".NET Elevation of Privilege Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x64",8.0.0,8.0.4,HIGH,CWE-416
+CVE-2024-21409,2024-04-17T18:21:57Z,".NET Elevation of Privilege Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x86",0,6.0.29,HIGH,CWE-416
+CVE-2024-21409,2024-04-17T18:21:57Z,".NET Elevation of Privilege Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x86",7.0.0,7.0.18,HIGH,CWE-416
+CVE-2024-21409,2024-04-17T18:21:57Z,".NET Elevation of Privilege Vulnerability","Microsoft.WindowsDesktop.App.Runtime.win-x86",8.0.0,8.0.4,HIGH,CWE-416
+CVE-2024-21643,2024-01-09T18:25:47Z,"Microsoft.IdentityModel.Protocols.SignedHttpRequest remote code execution vulnerability","Microsoft.IdentityModel.Protocols.SignedHttpRequest",0,6.34.0,HIGH,CWE-94
+CVE-2024-21643,2024-01-09T18:25:47Z,"Microsoft.IdentityModel.Protocols.SignedHttpRequest remote code execution vulnerability","Microsoft.IdentityModel.Protocols.SignedHttpRequest",7.0.0-preview,7.1.2,HIGH,CWE-94
+CVE-2024-21907,2022-06-22T15:08:47Z,"Improper Handling of Exceptional Conditions in Newtonsoft.Json",Newtonsoft.Json,0,13.0.1,HIGH,CWE-755
+CVE-2024-21908,2021-10-22T16:24:02Z,"Cross-site scripting vulnerability in TinyMCE",TinyMCE,0,5.9.0,MODERATE,CWE-79
+CVE-2024-21909,2022-01-21T23:35:35Z,"Denial of service in CBOR library",PeterO.Cbor,4.0.0,4.5.1,HIGH,CWE-407
+CVE-2024-21910,2021-11-02T15:42:52Z,"Cross-site scripting vulnerability in TinyMCE plugins",TinyMCE,0,5.10.0,MODERATE,CWE-64;CWE-79
+CVE-2024-21911,2021-01-06T19:27:54Z,"Cross-site scripting vulnerability in TinyMCE",TinyMCE,0,5.6.0,MODERATE,CWE-79
+CVE-2024-23838,2024-01-30T20:57:59Z,"TrueLayer.Client SSRF when fetching payment or payment provider",TrueLayer.Client,0,1.6.0,HIGH,CWE-918
+CVE-2024-24810,2024-02-08T18:23:49Z,"WiX Toolset's .be TEMP folder is vulnerable to DLL redirection attacks that allow the attacker to escalate privileges",wix,0,3.14.0,HIGH,CWE-426
+CVE-2024-24810,2024-02-08T18:23:49Z,"WiX Toolset's .be TEMP folder is vulnerable to DLL redirection attacks that allow the attacker to escalate privileges",wix,4.0.0,4.0.4,HIGH,CWE-426
+CVE-2024-26318,2024-02-19T06:30:33Z,"Cross-site Scripting in Serenity",Serenity.Net.Core,0,6.8.0,MODERATE,CWE-79
+CVE-2024-26470,2024-02-29T03:33:18Z,"FullStackHero's WebAPI Boilerplate host header injection vulnerability","FullStackHero.WebAPI.Boilerplate",1.0.0,,MODERATE,
+CVE-2024-27086,2024-04-16T21:41:57Z,"MSAL.NET applications targeting Xamarin Android and .NET Android (MAUI) susceptible to local denial of service","Microsoft.Identity.Client",4.48.0,4.59.1,LOW,CWE-863;CWE-926
+CVE-2024-27086,2024-04-16T21:41:57Z,"MSAL.NET applications targeting Xamarin Android and .NET Android (MAUI) susceptible to local denial of service","Microsoft.Identity.Client",4.60.0,4.60.3,LOW,CWE-863;CWE-926
+CVE-2024-27929,2024-03-05T16:26:15Z,"Use After Free in SixLabors.ImageSharp",SixLabors.ImageSharp,0,2.1.7,HIGH,CWE-416
+CVE-2024-27929,2024-03-05T16:26:15Z,"Use After Free in SixLabors.ImageSharp",SixLabors.ImageSharp,3.0.0,3.1.3,HIGH,CWE-416
+CVE-2024-28252,2024-03-15T19:20:17Z,"CoreWCF NetFraming based services can leave connections open when they should be closed",CoreWCF.NetFramingBase,1.4.0,1.4.2,HIGH,CWE-404
+CVE-2024-28252,2024-03-15T19:20:17Z,"CoreWCF NetFraming based services can leave connections open when they should be closed",CoreWCF.NetFramingBase,1.5.0,1.5.2,HIGH,CWE-404
+CVE-2024-28698,2024-07-22T18:31:48Z,"CLSA Directory Traversal vulnerability",Csla,0,5.5.4,CRITICAL,CWE-22
+CVE-2024-28698,2024-07-22T18:31:48Z,"CLSA Directory Traversal vulnerability",Csla,6.0.0,8.0.0,CRITICAL,CWE-22
+CVE-2024-28698,2024-07-22T18:31:48Z,"CLSA Directory Traversal vulnerability",Csla,7.0.0,8.0.0,CRITICAL,CWE-22
+CVE-2024-28868,2024-03-20T17:54:35Z,"Umbraco possible user enumeration ",UmbracoCMS,10.0.0,10.8.5,LOW,CWE-204
+CVE-2024-29035,2024-04-17T18:20:28Z,"Blind SSRF Leads to Port Scan by using Webhooks",Umbraco.Cms.Core,13.0.0,13.1.1,MODERATE,CWE-918
+CVE-2024-29035,2024-04-17T18:20:28Z,"Blind SSRF Leads to Port Scan by using Webhooks","Umbraco.Cms.Web.BackOffice",13.0.0,13.1.1,MODERATE,CWE-918
+CVE-2024-29187,2024-03-25T19:42:32Z,"WiX based installers are vulnerable to binary hijack when run as SYSTEM",wix,0,3.14.1,HIGH,CWE-732
+CVE-2024-29187,2024-03-25T19:42:32Z,"WiX based installers are vulnerable to binary hijack when run as SYSTEM",wix,4.0.0,4.0.5,HIGH,CWE-732
+CVE-2024-29187,2024-03-25T19:42:32Z,"WiX based installers are vulnerable to binary hijack when run as SYSTEM",WixToolset.Sdk,0,4.0.5,HIGH,CWE-732
+CVE-2024-29188,2024-03-25T19:42:17Z,"Malicious directory junction can cause WiX RemoveFoldersEx to possibly delete elevated files",wix,0,3.14.1,HIGH,CWE-59
+CVE-2024-29188,2024-03-25T19:42:17Z,"Malicious directory junction can cause WiX RemoveFoldersEx to possibly delete elevated files",wix,4.0.0,4.0.5,HIGH,CWE-59
+CVE-2024-29188,2024-03-25T19:42:17Z,"Malicious directory junction can cause WiX RemoveFoldersEx to possibly delete elevated files",WixToolset.Util.wixext,0,4.0.5,HIGH,CWE-59
+CVE-2024-29203,2024-03-26T21:23:47Z,"TinyMCE Cross-Site Scripting (XSS) vulnerability in handling iframes",TinyMCE,0,6.8.1,MODERATE,CWE-79
+CVE-2024-29857,2024-05-14T15:32:54Z,"Bouncy Castle certificate parsing issues cause high CPU usage during parameter evaluation.",BouncyCastle,0,,MODERATE,CWE-125;CWE-400
+CVE-2024-29857,2024-05-14T15:32:54Z,"Bouncy Castle certificate parsing issues cause high CPU usage during parameter evaluation.","BouncyCastle.Cryptography",0,2.3.1,MODERATE,CWE-125;CWE-400
+CVE-2024-29881,2024-03-26T21:23:45Z,"TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements",TinyMCE,0,7.0.0,MODERATE,CWE-79
+CVE-2024-29992,2024-04-09T18:30:28Z,"Azure Identity Library for .NET Information Disclosure Vulnerability",Azure.Identity,0,1.11.0,MODERATE,CWE-522
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm64",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-arm",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm64",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-arm",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-musl-x64",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.linux-x64",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-arm64",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.osx-x64",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm64",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-arm",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x64",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",7.0.0,7.0.19,MODERATE,CWE-122
+CVE-2024-30045,2024-05-14T20:30:57Z,"Microsoft Security Advisory CVE-2024-30045 | .NET Remote code Execution Vulnerability","Microsoft.NETCore.App.Runtime.win-x86",8.0.0,8.0.5,MODERATE,CWE-122
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",7.0.0,7.0.19,MODERATE,CWE-362
+CVE-2024-30046,2024-05-14T20:31:00Z,"Microsoft Security Advisory CVE-2024-30046 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",8.0.0,8.0.5,MODERATE,CWE-362
+CVE-2024-30054,2024-05-14T18:31:05Z,"Microsoft Power BI Client JavaScript SDK Information Disclosure Vulnerability","Microsoft.PowerBI.JavaScript",0,,MODERATE,CWE-20
+CVE-2024-30105,2024-07-09T21:14:10Z,"Microsoft Security Advisory CVE-2024-30105 | .NET Denial of Service Vulnerability",System.Text.Json,7.0.0,8.0.4,HIGH,CWE-400
+CVE-2024-30171,2024-05-14T15:32:54Z,"Bouncy Castle affected by timing side-channel for RSA key exchange (""The Marvin Attack"")",BouncyCastle,0,,MODERATE,CWE-203
+CVE-2024-30171,2024-05-14T15:32:54Z,"Bouncy Castle affected by timing side-channel for RSA key exchange (""The Marvin Attack"")","BouncyCastle.Cryptography",0,2.3.1,MODERATE,CWE-203
+CVE-2024-30172,2024-05-14T15:32:54Z,"Bouncy Castle crafted signature and public key can be used to trigger an infinite loop",BouncyCastle,0,,MODERATE,CWE-835
+CVE-2024-30172,2024-05-14T15:32:54Z,"Bouncy Castle crafted signature and public key can be used to trigger an infinite loop","BouncyCastle.Cryptography",0,2.3.1,MODERATE,CWE-835
+CVE-2024-32028,2024-04-12T22:54:09Z,"Sensitive query parameters logged by default in OpenTelemetry.Instrumentation http and AspNetCore","OpenTelemetry.Instrumentation.AspNetCore",0,1.8.1,MODERATE,CWE-201;CWE-212
+CVE-2024-32028,2024-04-12T22:54:09Z,"Sensitive query parameters logged by default in OpenTelemetry.Instrumentation http and AspNetCore","OpenTelemetry.Instrumentation.Http",0,1.8.1,MODERATE,CWE-201;CWE-212
+CVE-2024-32035,2024-04-15T20:22:54Z,"SixLabors.ImageSharp vulnerable to Memory Allocation with Excessive Size Value",SixLabors.ImageSharp,0,2.1.8,MODERATE,CWE-789
+CVE-2024-32035,2024-04-15T20:22:54Z,"SixLabors.ImageSharp vulnerable to Memory Allocation with Excessive Size Value",SixLabors.ImageSharp,3.0.0,3.1.4,MODERATE,CWE-789
+CVE-2024-32036,2024-04-15T20:24:06Z,"SixLabors.ImageSharp vulnerable to data leakage",SixLabors.ImageSharp,0,2.1.8,MODERATE,CWE-226
+CVE-2024-32036,2024-04-15T20:24:06Z,"SixLabors.ImageSharp vulnerable to data leakage",SixLabors.ImageSharp,3.0.0,3.1.4,MODERATE,CWE-226
+CVE-2024-32655,2024-05-09T15:12:49Z,"Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow",Npgsql,0,4.0.14,HIGH,CWE-190;CWE-89
+CVE-2024-32655,2024-05-09T15:12:49Z,"Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow",Npgsql,4.1.0,4.1.13,HIGH,CWE-190;CWE-89
+CVE-2024-32655,2024-05-09T15:12:49Z,"Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow",Npgsql,5.0.0,5.0.18,HIGH,CWE-190;CWE-89
+CVE-2024-32655,2024-05-09T15:12:49Z,"Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow",Npgsql,6.0.0,6.0.11,HIGH,CWE-190;CWE-89
+CVE-2024-32655,2024-05-09T15:12:49Z,"Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow",Npgsql,7.0.0,7.0.7,HIGH,CWE-190;CWE-89
+CVE-2024-32655,2024-05-09T15:12:49Z,"Npgsql vulnerable to SQL Injection via Protocol Message Size Overflow",Npgsql,8.0.0,8.0.3,HIGH,CWE-190;CWE-89
+CVE-2024-32872,2024-04-24T17:04:34Z,"Umbraco Workflow's Backoffice users can execute arbitrary SQL",Plumber.Workflow,0,10.1.2,MODERATE,CWE-89
+CVE-2024-32872,2024-04-24T17:04:34Z,"Umbraco Workflow's Backoffice users can execute arbitrary SQL",Umbraco.Workflow,0,10.3.9,MODERATE,CWE-89
+CVE-2024-32872,2024-04-24T17:04:34Z,"Umbraco Workflow's Backoffice users can execute arbitrary SQL",Umbraco.Workflow,11.0.0-rc1,12.2.6,MODERATE,CWE-89
+CVE-2024-32872,2024-04-24T17:04:34Z,"Umbraco Workflow's Backoffice users can execute arbitrary SQL",Umbraco.Workflow,13.0.0-rc1,13.0.6,MODERATE,CWE-89
+CVE-2024-33862,2024-07-06T00:31:06Z,"OPCFoundation.NetStandard.Opc.Ua.Core buffer-management vulnerability","OPCFoundation.NetStandard.Opc.Ua.Core",0,1.5.374.54,HIGH,CWE-770
+CVE-2024-34071,2024-05-21T14:29:18Z,"Umbraco CMS Open Redirect Bypass Protection  ",UmbracoCms.Core,10.5.0,10.8.6,MODERATE,CWE-601
+CVE-2024-34071,2024-05-21T14:29:18Z,"Umbraco CMS Open Redirect Bypass Protection  ",UmbracoCms.Core,12.0.0,12.3.10,MODERATE,CWE-601
+CVE-2024-34071,2024-05-21T14:29:18Z,"Umbraco CMS Open Redirect Bypass Protection  ",UmbracoCms.Core,13.0.0,13.3.1,MODERATE,CWE-601
+CVE-2024-34071,2024-05-21T14:29:18Z,"Umbraco CMS Open Redirect Bypass Protection  ",UmbracoCms.Core,8.18.5,8.18.14,MODERATE,CWE-601
+CVE-2024-34071,2024-05-21T14:29:18Z,"Umbraco CMS Open Redirect Bypass Protection  ","Umbraco.Cms.Web.BackOffice",10.5.0,10.8.6,MODERATE,CWE-601
+CVE-2024-34071,2024-05-21T14:29:18Z,"Umbraco CMS Open Redirect Bypass Protection  ","Umbraco.Cms.Web.BackOffice",12.0.0,12.3.10,MODERATE,CWE-601
+CVE-2024-34071,2024-05-21T14:29:18Z,"Umbraco CMS Open Redirect Bypass Protection  ","Umbraco.Cms.Web.BackOffice",13.0.0,13.3.1,MODERATE,CWE-601
+CVE-2024-34071,2024-05-21T14:29:18Z,"Umbraco CMS Open Redirect Bypass Protection  ","Umbraco.Cms.Web.BackOffice",8.18.5,8.18.14,MODERATE,CWE-601
+CVE-2024-35218,2024-05-21T14:47:24Z,"Umbraco CMS Vulnerable to Stored XSS on Content Page Through Markdown Editor Preview Pane",UmbracoCms.Core,10.0.0,10.8.4,MODERATE,CWE-79
+CVE-2024-35218,2024-05-21T14:47:24Z,"Umbraco CMS Vulnerable to Stored XSS on Content Page Through Markdown Editor Preview Pane",UmbracoCms.Core,12.0.0,12.3.7,MODERATE,CWE-79
+CVE-2024-35218,2024-05-21T14:47:24Z,"Umbraco CMS Vulnerable to Stored XSS on Content Page Through Markdown Editor Preview Pane",UmbracoCms.Core,13.0.0,13.1.1,MODERATE,CWE-79
+CVE-2024-35218,2024-05-21T14:47:24Z,"Umbraco CMS Vulnerable to Stored XSS on Content Page Through Markdown Editor Preview Pane",UmbracoCms.Core,8.0.0,8.18.13,MODERATE,CWE-79
+CVE-2024-35239,2024-05-28T20:40:31Z,"Umbraco Forms components vulnerable to Stored Cross-site Scripting",Umbraco.Forms,10.0.0,10.5.3,LOW,CWE-79
+CVE-2024-35239,2024-05-28T20:40:31Z,"Umbraco Forms components vulnerable to Stored Cross-site Scripting",Umbraco.Forms,12.0.0,12.2.2,LOW,CWE-79
+CVE-2024-35239,2024-05-28T20:40:31Z,"Umbraco Forms components vulnerable to Stored Cross-site Scripting",Umbraco.Forms,13.0.0,13.0.1,LOW,CWE-79
+CVE-2024-35239,2024-05-28T20:40:31Z,"Umbraco Forms components vulnerable to Stored Cross-site Scripting",Umbraco.Forms,8.0.0,8.13.13,LOW,CWE-79
+CVE-2024-35240,2024-05-28T21:18:04Z,"Umbraco Commerce vulnerable to Stored Cross-site Scripting on Print Functionality",Umbraco.Commerce,0,10.0.5,MODERATE,CWE-79
+CVE-2024-35240,2024-05-28T21:18:04Z,"Umbraco Commerce vulnerable to Stored Cross-site Scripting on Print Functionality",Umbraco.Commerce,12.0.0,12.1.4,MODERATE,CWE-79
+CVE-2024-35252,2024-06-11T18:30:50Z,"Azure Storage Movement Client Library Denial of Service Vulnerability","Microsoft.Azure.Storage.DataMovement",0,2.0.5,HIGH,CWE-1104
+CVE-2024-35255,2024-06-11T18:30:50Z,"Azure Identity Libraries and Microsoft Authentication Library Elevation of Privilege Vulnerability",Azure.Identity,0,1.11.4,MODERATE,CWE-362
+CVE-2024-35255,2024-06-11T18:30:50Z,"Azure Identity Libraries and Microsoft Authentication Library Elevation of Privilege Vulnerability","Microsoft.Identity.Client",4.49.1,4.60.4,MODERATE,CWE-362
+CVE-2024-35255,2024-06-11T18:30:50Z,"Azure Identity Libraries and Microsoft Authentication Library Elevation of Privilege Vulnerability","Microsoft.Identity.Client",4.61.0,4.61.3,MODERATE,CWE-362
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-arm64",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-35264,2024-07-09T21:14:23Z,"Microsoft Security Advisory CVE-2024-35264 | .NET Remote Code Execution Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",8.0.0,8.0.7,HIGH,CWE-416
+CVE-2024-38081,2024-07-09T21:14:35Z,"Microsoft Security Advisory CVE-2024-38081 | .NET Denial of Service Vulnerability",Microsoft.IO.Redist,4.6.0-preview.18571.3,6.0.1,HIGH,CWE-59
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-arm",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-arm64",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-arm64",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-arm",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-musl-arm",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-musl-arm64",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-musl-arm",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-musl-x64",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-musl-x64",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-x64",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.linux-x64",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.osx-arm64",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.osx-arm64",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.osx-x64",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.osx-x64",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-arm",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-arm64",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-arm64",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-arm",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-x64",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-x64",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-x86",6.0.0,6.0.32,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability","Microsoft.NetCore.App.Runtime.win-x86",8.0.0,8.0.7,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability",System.Formats.Asn1,5.0.0-preview.7.20364.11,6.0.1,HIGH,CWE-20
+CVE-2024-38095,2024-07-09T21:14:53Z,"Microsoft Security Advisory CVE-2024-38095 | .NET Denial of Service Vulnerability",System.Formats.Asn1,7.0.0-preview.1.22076.8,8.0.1,HIGH,CWE-20
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.linux-arm64",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.linux-arm",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.linux-musl-arm64",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.linux-musl-arm",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.linux-musl-x64",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.linux-x64",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.osx-arm64",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.osx-x64",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.win-arm64",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.win-arm",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.win-x64",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38167,2024-08-13T19:26:10Z,"Microsoft Security Advisory CVE-2024-38167 | .NET Information Disclosure Vulnerability","Microsoft.NetCore.App.Runtime.win-x86",8.0.0,8.0.8,MODERATE,CWE-319
+CVE-2024-38168,2024-08-13T19:27:23Z,"Microsoft Security Advisory CVE-2024-38168 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",8.0.0,8.0.8,HIGH,CWE-400
+CVE-2024-38168,2024-08-13T19:27:23Z,"Microsoft Security Advisory CVE-2024-38168 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",8.0.0,8.0.8,HIGH,CWE-400
+CVE-2024-38168,2024-08-13T19:27:23Z,"Microsoft Security Advisory CVE-2024-38168 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",8.0.0,8.0.8,HIGH,CWE-400
+CVE-2024-38168,2024-08-13T19:27:23Z,"Microsoft Security Advisory CVE-2024-38168 | .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",8.0.0,8.0.8,HIGH,CWE-400
+CVE-2024-38356,2024-06-19T15:07:08Z,"TinyMCE Cross-Site Scripting (XSS) vulnerability using noneditable_regexp option",TinyMCE,0,5.11.0,MODERATE,CWE-79
+CVE-2024-38356,2024-06-19T15:07:08Z,"TinyMCE Cross-Site Scripting (XSS) vulnerability using noneditable_regexp option",TinyMCE,6.0.0,6.8.4,MODERATE,CWE-79
+CVE-2024-38356,2024-06-19T15:07:08Z,"TinyMCE Cross-Site Scripting (XSS) vulnerability using noneditable_regexp option",TinyMCE,7.0.0,7.2.0,MODERATE,CWE-79
+CVE-2024-38357,2024-06-19T15:07:03Z,"TinyMCE Cross-Site Scripting (XSS) vulnerability using noscript elements",TinyMCE,0,5.11.0,MODERATE,CWE-79
+CVE-2024-38357,2024-06-19T15:07:03Z,"TinyMCE Cross-Site Scripting (XSS) vulnerability using noscript elements",TinyMCE,6.0.0,6.8.4,MODERATE,CWE-79
+CVE-2024-38357,2024-06-19T15:07:03Z,"TinyMCE Cross-Site Scripting (XSS) vulnerability using noscript elements",TinyMCE,7.0.0,7.2.0,MODERATE,CWE-79
+CVE-2024-39677,2024-07-08T14:20:33Z,"NHibernate SQL injection vulnerability in discriminator mappings, static fields referenced in HQL, and some utilities",NHibernate,0,5.4.9,MODERATE,CWE-89
+CVE-2024-39677,2024-07-08T14:20:33Z,"NHibernate SQL injection vulnerability in discriminator mappings, static fields referenced in HQL, and some utilities",NHibernate,5.5.0,5.5.2,MODERATE,CWE-89
+CVE-2024-39694,2024-07-31T15:28:54Z,"IdentityServer Open Redirect vulnerability",Duende.IdentityServer,6.0.0-preview.1,6.0.5,MODERATE,CWE-601
+CVE-2024-39694,2024-07-31T15:28:54Z,"IdentityServer Open Redirect vulnerability",Duende.IdentityServer,6.1.0-preview.1,6.1.8,MODERATE,CWE-601
+CVE-2024-39694,2024-07-31T15:28:54Z,"IdentityServer Open Redirect vulnerability",Duende.IdentityServer,6.2.0-preview.1,6.2.5,MODERATE,CWE-601
+CVE-2024-39694,2024-07-31T15:28:54Z,"IdentityServer Open Redirect vulnerability",Duende.IdentityServer,6.3.0-preview.1,6.3.10,MODERATE,CWE-601
+CVE-2024-39694,2024-07-31T15:28:54Z,"IdentityServer Open Redirect vulnerability",Duende.IdentityServer,7.0.0-preview.1,7.0.6,MODERATE,CWE-601
+CVE-2024-39694,2024-07-31T15:28:54Z,"IdentityServer Open Redirect vulnerability",IdentityServer4,0,,MODERATE,CWE-601
+CVE-2024-40636,2024-07-17T16:00:10Z,"Steeltoe Leaks Basic Auth Credentials to Logs After Fetch Registry Error","Steeltoe.Discovery.ClientAutofac",0,,LOW,CWE-532
+CVE-2024-40636,2024-07-17T16:00:10Z,"Steeltoe Leaks Basic Auth Credentials to Logs After Fetch Registry Error","Steeltoe.Discovery.ClientCore",0,,LOW,CWE-532
+CVE-2024-40636,2024-07-17T16:00:10Z,"Steeltoe Leaks Basic Auth Credentials to Logs After Fetch Registry Error","Steeltoe.Discovery.Eureka",0,3.2.8,LOW,CWE-532
+CVE-2024-40636,2024-07-17T16:00:10Z,"Steeltoe Leaks Basic Auth Credentials to Logs After Fetch Registry Error","Steeltoe.Discovery.EurekaBase",0,,LOW,CWE-532
+CVE-2024-41131,2024-07-22T17:42:07Z,"SixLabors ImageSharp Out-of-bounds Write",SixLabors.ImageSharp,0,2.1.9,HIGH,CWE-787
+CVE-2024-41131,2024-07-22T17:42:07Z,"SixLabors ImageSharp Out-of-bounds Write",SixLabors.ImageSharp,3.0.0,3.1.5,HIGH,CWE-787
+CVE-2024-41132,2024-07-22T17:42:33Z,"SixLabors ImageSharp has Excessive Memory Allocation in Gif Decoder",SixLabors.ImageSharp,0,2.1.9,MODERATE,CWE-789
+CVE-2024-41132,2024-07-22T17:42:33Z,"SixLabors ImageSharp has Excessive Memory Allocation in Gif Decoder",SixLabors.ImageSharp,3.0.0,3.1.5,MODERATE,CWE-789
+CVE-2024-41799,2024-07-29T16:44:15Z,"tgstation-server's DreamMaker environment files outside the deployment directory can be compiled and ran by insufficiently permissioned users",Tgstation.Server.Api,4.0.0,6.8.0,HIGH,CWE-22
+CVE-2024-41799,2024-07-29T16:44:15Z,"tgstation-server's DreamMaker environment files outside the deployment directory can be compiled and ran by insufficiently permissioned users",Tgstation.Server.Host,4.0.0,6.8.0,HIGH,CWE-22
+CVE-2024-43376,2024-08-20T18:25:15Z,"Umbraco CMS vulnerable to Generation of Error Message Containing Sensitive Information","Umbraco.Cms.Api.Management",14.0.0,14.1.2,MODERATE,CWE-209
+CVE-2024-43377,2024-08-20T18:32:26Z,"Umbraco CMS Improper Access Control vulnerability",Umbraco.Cms,14.0.0,14.1.2,MODERATE,CWE-284
+CVE-2024-6484,2024-07-11T18:31:14Z,"Bootstrap Cross-Site Scripting (XSS) vulnerability",bootstrap,2.0.0,,MODERATE,CWE-79
+CVE-2024-6484,2024-07-11T18:31:14Z,"Bootstrap Cross-Site Scripting (XSS) vulnerability",bootstrap.sass,2.0.0,,MODERATE,CWE-79
+CVE-2024-6531,2024-07-11T18:31:14Z,"Bootstrap Cross-Site Scripting (XSS) vulnerability",bootstrap,4.0.0,,MODERATE,CWE-79
+CVE-2024-6531,2024-07-11T18:31:14Z,"Bootstrap Cross-Site Scripting (XSS) vulnerability",bootstrap.sass,4.0.0,,MODERATE,CWE-79
+GHSA-259p-rvjx-ffwg,2024-02-08T18:24:21Z,"Panel::Software Customized WiX .be TEMP folder is vulnerable to DLL redirection attacks that allow the attacker to escalate privileges",PanelSW.Custom.WiX,0,3.15.0-a44,HIGH,CWE-426
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm64",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-arm64",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-musl-x64",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-x64",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.osx-x64",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-arm64",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x64",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",3.1.0,3.1.28,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","Microsoft.AspNetCore.App.Runtime.win-x86",6.0.0,6.0.8,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","System.Security.Cryptography.Xml",0,4.7.1,MODERATE,
+GHSA-2m65-m22p-9wjw,2022-08-10T00:00:18Z,"Duplicate Advisory: .NET Information Disclosure Vulnerability","System.Security.Cryptography.Xml",5.0.0,6.0.1,MODERATE,
+GHSA-2x7m-gf85-3745,2024-03-13T17:14:43Z,"Remote Denial of Service Vulnerability in Microsoft QUIC","Microsoft.Native.Quic.MsQuic.OpenSSL",0,2.1.12,HIGH,CWE-401
+GHSA-2x7m-gf85-3745,2024-03-13T17:14:43Z,"Remote Denial of Service Vulnerability in Microsoft QUIC","Microsoft.Native.Quic.MsQuic.OpenSSL",2.2.0,2.2.7,HIGH,CWE-401
+GHSA-2x7m-gf85-3745,2024-03-13T17:14:43Z,"Remote Denial of Service Vulnerability in Microsoft QUIC","Microsoft.Native.Quic.MsQuic.OpenSSL",2.3.0,2.3.5,HIGH,CWE-401
+GHSA-2x7m-gf85-3745,2024-03-13T17:14:43Z,"Remote Denial of Service Vulnerability in Microsoft QUIC","Microsoft.Native.Quic.MsQuic.Schannel",0,2.1.12,HIGH,CWE-401
+GHSA-2x7m-gf85-3745,2024-03-13T17:14:43Z,"Remote Denial of Service Vulnerability in Microsoft QUIC","Microsoft.Native.Quic.MsQuic.Schannel",2.2.0,2.2.7,HIGH,CWE-401
+GHSA-2x7m-gf85-3745,2024-03-13T17:14:43Z,"Remote Denial of Service Vulnerability in Microsoft QUIC","Microsoft.Native.Quic.MsQuic.Schannel",2.3.0,2.3.5,HIGH,CWE-401
+GHSA-32q7-gv7f-4cg5,2024-02-13T18:38:24Z,"Duplicate Advisory: Microsoft Security Advisory CVE-2024-21386: .NET Denial of Service Vulnerability","Microsoft.AspNetCore.App.Runtime.linux-arm",0,6.0.27,HIGH,CWE-400
+GHSA-3m2r-q8x3-xmf7,2018-10-16T19:59:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.All, Microsoft.AspNetCore.Server.Kestrel.Core, Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions, and Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv",Microsoft.AspNetCore.All,2.0.0,2.0.8,MODERATE,
+GHSA-3m2r-q8x3-xmf7,2018-10-16T19:59:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.All, Microsoft.AspNetCore.Server.Kestrel.Core, Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions, and Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv","Microsoft.AspNetCore.Server.Kestrel.Core",2.0.0,2.0.3,MODERATE,
+GHSA-3m2r-q8x3-xmf7,2018-10-16T19:59:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.All, Microsoft.AspNetCore.Server.Kestrel.Core, Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions, and Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv","Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions",2.0.0,2.0.3,MODERATE,
+GHSA-3m2r-q8x3-xmf7,2018-10-16T19:59:48Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.All, Microsoft.AspNetCore.Server.Kestrel.Core, Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions, and Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv","Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv",2.0.0,2.0.3,MODERATE,
+GHSA-3w9w-9833-gcpv,2023-01-26T19:52:50Z,"Security bug in ConvertToSinglePlane when used with untrusted content from the DDS loader",directxtex_desktop_2019,0,2023.1.31.1,MODERATE,
+GHSA-3w9w-9833-gcpv,2023-01-26T19:52:50Z,"Security bug in ConvertToSinglePlane when used with untrusted content from the DDS loader",directxtex_desktop_win10,0,2023.1.31.1,MODERATE,
+GHSA-3w9w-9833-gcpv,2023-01-26T19:52:50Z,"Security bug in ConvertToSinglePlane when used with untrusted content from the DDS loader",directxtex_uwp,0,2023.1.31.1,MODERATE,
+GHSA-4c29-gfrp-g6x9,2023-10-05T13:22:50Z,"CefSharp affected by libvpx's heap buffer overflow in vp8 encoding",CefSharp.Common,0,117.2.20,HIGH,
+GHSA-4c29-gfrp-g6x9,2023-10-05T13:22:50Z,"CefSharp affected by libvpx's heap buffer overflow in vp8 encoding",CefSharp.Common.NETCore,0,117.2.20,HIGH,
+GHSA-4vr3-9v7h-5f8v,2019-06-18T15:38:41Z,"Low severity vulnerability that affects Gw2Sharp",Gw2Sharp,0,0.3.1,LOW,
+GHSA-55p7-v223-x366,2024-07-31T19:57:33Z,"IdentityServer Open Redirect vulnerability",IdentityServer4,0,,MODERATE,CWE-601
+GHSA-6r78-m64m-qwcf,2023-08-10T19:25:23Z,"Moq v4.20.0-rc to 4.20.1 share hashed user data",moq,4.20.0-rc,4.20.2,LOW,
+GHSA-6r7c-6w96-8pvw,2021-12-07T21:21:49Z,"Remote Code Execution in AjaxNetProfessional",AjaxNetProfessional,0,21.11.29.1,CRITICAL,CWE-502
+GHSA-7r36-jf3c-jhp4,2022-05-13T01:50:31Z,"Duplicate Advisory: tgstation-server vulnerable to cached user logins in legacy server",TGServiceInterface,3.2.1.0,3.2.5.0,CRITICAL,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.",Imageflow.AllPlatforms,0,0.10.2,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeRuntime.osx_10_11-x86_64",0,,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeRuntime.osx-x86_64",0,2.0.0-preview6,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeRuntime.ubuntu_16_04-x86_64",0,,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeRuntime.ubuntu_18_04-x86_64",0,,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeRuntime.ubuntu_18_04-x86_64-haswell",0,,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeRuntime.ubuntu-x86_64",0,2.0.0-preview6,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeRuntime.ubuntu-x86_64-haswell",0,2.0.0-preview6,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeRuntime.win-x86",0,2.0.0-preview6,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeRuntime.win-x86_64",0,2.0.0-preview6,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeTool.osx_10_11-x86_64",0,,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeTool.osx-x86_64",0,2.0.0-preview6,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeTool.ubuntu_16_04-x86_64",0,,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeTool.ubuntu_18_04-x86_64",0,,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeTool.ubuntu_18_04-x86_64-haswell",0,,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeTool.ubuntu-x86_64",0,2.0.0-preview6,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeTool.ubuntu-x86_64-haswell",0,2.0.0-preview6,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeTool.win-x86",0,2.0.0-preview6,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","Imageflow.NativeTool.win-x86_64",0,2.0.0-preview6,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.",Imageflow.Server,0,0.8.2,HIGH,
+GHSA-7vpr-3ppw-qrpj,2023-09-27T21:16:16Z,"Imageflow affected by libwebp zero-day and should not be used with malicious source images.","ImageResizer.Plugins.Imageflow",0,5.0.12,HIGH,
+GHSA-8g9c-28fc-mcx2,2024-01-09T18:28:03Z,"Duplicate Advisory: Microsoft Identity Denial of service vulnerability","Microsoft.IdentityModel.JsonWebTokens",0,5.7.0,MODERATE,CWE-20
+GHSA-8g9c-28fc-mcx2,2024-01-09T18:28:03Z,"Duplicate Advisory: Microsoft Identity Denial of service vulnerability","Microsoft.IdentityModel.JsonWebTokens",6.5.0,6.34.0,MODERATE,CWE-20
+GHSA-8g9c-28fc-mcx2,2024-01-09T18:28:03Z,"Duplicate Advisory: Microsoft Identity Denial of service vulnerability","Microsoft.IdentityModel.JsonWebTokens",7.0.0-preview,7.1.2,MODERATE,CWE-20
+GHSA-8g9c-28fc-mcx2,2024-01-09T18:28:03Z,"Duplicate Advisory: Microsoft Identity Denial of service vulnerability","System.IdentityModel.Tokens.Jwt",0,5.7.0,MODERATE,CWE-20
+GHSA-8g9c-28fc-mcx2,2024-01-09T18:28:03Z,"Duplicate Advisory: Microsoft Identity Denial of service vulnerability","System.IdentityModel.Tokens.Jwt",6.5.0,6.34.0,MODERATE,CWE-20
+GHSA-8g9c-28fc-mcx2,2024-01-09T18:28:03Z,"Duplicate Advisory: Microsoft Identity Denial of service vulnerability","System.IdentityModel.Tokens.Jwt",7.0.0-preview,7.1.2,MODERATE,CWE-20
+GHSA-8rfx-6mr3-5jh3,2024-01-03T18:30:51Z,"Duplicate Advisory: Improper Handling of Exceptional Conditions in Newtonsoft.Json",Newtonsoft.Json,0,13.0.1,HIGH,CWE-755
+GHSA-8v28-3g86-chj5,2024-02-08T18:24:35Z,"PanelSwWix4.Sdk  .be TEMP folder is vulnerable to DLL redirection attacks that allow the attacker to escalate privileges",PanelSwWix4.Sdk,0,5.0.0-psw-wix.0251-40,HIGH,CWE-426
+GHSA-9qcm-fqj9-93m4,2022-12-13T21:30:26Z,"Duplicate Advisory: .NET Framework Remote Code Execution Vulnerability.","Microsoft.WindowsDesktop.App.Runtime.win-x64",3.1.0,3.1.32,HIGH,
+GHSA-9wx7-jrvc-28mm,2021-11-08T21:51:18Z,"Signature verification vulnerability in Stark Bank ecdsa libraries",starkbank-ecdsa,1.3.1,1.3.2,HIGH,CWE-347
+GHSA-cgpw-2gph-2r9g,2018-10-16T19:59:59Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.All, Microsoft.AspNetCore.App, and Microsoft.AspNetCore.Server.Kestrel.Core",Microsoft.AspNetCore.All,2.0.0,2.0.9,MODERATE,
+GHSA-cgpw-2gph-2r9g,2018-10-16T19:59:59Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.All, Microsoft.AspNetCore.App, and Microsoft.AspNetCore.Server.Kestrel.Core",Microsoft.AspNetCore.All,2.1.0,2.1.2,MODERATE,
+GHSA-cgpw-2gph-2r9g,2018-10-16T19:59:59Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.All, Microsoft.AspNetCore.App, and Microsoft.AspNetCore.Server.Kestrel.Core",Microsoft.AspNetCore.App,2.1.0,2.1.2,MODERATE,
+GHSA-cgpw-2gph-2r9g,2018-10-16T19:59:59Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.All, Microsoft.AspNetCore.App, and Microsoft.AspNetCore.Server.Kestrel.Core","Microsoft.AspNetCore.Server.Kestrel.Core",2.0.0,2.0.4,MODERATE,
+GHSA-cgpw-2gph-2r9g,2018-10-16T19:59:59Z,"Moderate severity vulnerability that affects Microsoft.AspNetCore.All, Microsoft.AspNetCore.App, and Microsoft.AspNetCore.Server.Kestrel.Core","Microsoft.AspNetCore.Server.Kestrel.Core",2.1.0,2.1.2,MODERATE,
+GHSA-cxw4-9qv9-vx5h,2019-09-30T19:42:28Z,"High severity vulnerability that affects PeterO.Cbor",PeterO.Cbor,0,4.0.0,HIGH,
+GHSA-g4v6-69p6-q3p4,2024-03-25T19:36:25Z,"WiX Burn-based bundles are vulnerable to binary hijack when run as SYSTEM ",PanelSwWix4.Sdk,0,5.0.0-psw-wix.0265-49,HIGH,
+GHSA-g8q2-24jh-5hpc,2018-07-27T14:47:52Z,"High severity vulnerability that affects jquery-ui",jQuery.UI.Combined,0,1.12.0,HIGH,
+GHSA-gmc6-fwg3-75m5,2024-07-11T17:42:20Z,"Mimekit has vulnerable dependency that can lead to denial of service",MimeKit,3.0.0,4.7.1,HIGH,CWE-20
+GHSA-gpv5-rp6w-58r8,2022-11-22T00:13:44Z,"Remote code execution vulnerability in dependency System.Drawing.Common",Akka,0,1.4.46,MODERATE,
+GHSA-gpv5-rp6w-58r8,2022-11-22T00:13:44Z,"Remote code execution vulnerability in dependency System.Drawing.Common",Akka,1.5.0-alpha1,1.5.0-alpha3,MODERATE,
+GHSA-hf3r-vmrv-7w29,2024-01-03T18:30:51Z,"Duplicate Advisory: Denial of service in CBOR library",PeterO.Cbor,4.0.0,4.5.1,HIGH,CWE-407
+GHSA-j646-gj5p-p45g,2023-09-21T17:11:42Z,"CefSharp affected by heap buffer overflow in WebP",CefSharp.Common,0,116.0.230,CRITICAL,
+GHSA-j646-gj5p-p45g,2023-09-21T17:11:42Z,"CefSharp affected by heap buffer overflow in WebP",CefSharp.Common.NETCore,0,116.0.230,CRITICAL,
+GHSA-jcmq-5rrv-j2g4,2024-02-02T21:04:47Z,"PowerShell is subject to remote code execution vulnerability",PowerShell,0,7.0.0,HIGH,
+GHSA-jw42-5m4v-9c8g,2024-01-09T18:30:27Z,"Duplicate Advisory: NuGet Client Security Feature Bypass Vulnerability  ",NuGet.CommandLine,6.8.0,6.8.1,CRITICAL,CWE-20
+GHSA-qrmm-w75w-3wpx,2021-12-09T19:08:38Z,"Server side request forgery in SwaggerUI","Swashbuckle.AspNetCore.SwaggerUI",0,6.3.0,MODERATE,CWE-918
+GHSA-qv8q-v995-72gr,2020-09-09T17:29:38Z,"personnummer/csharp vulnerable to Improper Input Validation",Personnummer,0,3.0.2,LOW,
+GHSA-qxx8-292g-2w66,2021-03-08T15:50:01Z,"Improper Authentication",Microsoft.Bot.Connector,4.10.0,4.10.3,HIGH,CWE-287
+GHSA-qxx8-292g-2w66,2021-03-08T15:50:01Z,"Improper Authentication",Microsoft.Bot.Connector,4.6.0,4.6.4,HIGH,CWE-287
+GHSA-qxx8-292g-2w66,2021-03-08T15:50:01Z,"Improper Authentication",Microsoft.Bot.Connector,4.7.0,4.7.3,HIGH,CWE-287
+GHSA-qxx8-292g-2w66,2021-03-08T15:50:01Z,"Improper Authentication",Microsoft.Bot.Connector,4.8.0,4.8.2,HIGH,CWE-287
+GHSA-qxx8-292g-2w66,2021-03-08T15:50:01Z,"Improper Authentication",Microsoft.Bot.Connector,4.9.0,4.9.5,HIGH,CWE-287
+GHSA-vx2x-9cff-fhjw,2022-12-06T21:13:49Z,"DSInternals Credential Roaming Elevation of Privilege Vulnerability",DSInternals.Common,2.21,4.8,MODERATE,
+GHSA-w4x6-hh3x-wjrx,2023-12-11T21:47:14Z,"Stale copy of the public suffix list",Gsemac.Net,0,0.38.2,LOW,
+GHSA-wq88-fq4x-h2pm,2024-03-25T19:35:53Z,"WiX Burn-based bundles are vulnerable to binary hijack when run as SYSTEM",PanelSW.Custom.WiX,0,3.15.0-a46,HIGH,
+GHSA-wqcr-xm43-hpqr,2023-10-06T20:46:33Z,"Vulnerable version of libwebp and can be exploited with a malicious source image","ImageResizer.Plugins.FreeImage",0,,HIGH,

--- a/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
@@ -17,9 +17,11 @@ package org.openrewrite.csharp.dependencies;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.csharp.dependencies.table.VulnerabilityReport;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.xml.Assertions.xml;
 
 class DependencyVulnerabilityCheckTest implements RewriteTest {
@@ -56,9 +58,38 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
     }
 
     @Test
+    void updateSecondWithinDifferentRange() {
+        rewriteRun(
+          xml(
+            //language=xml
+            """
+              <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                <ItemGroup>
+                  <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.1" />
+                </ItemGroup>
+              </Project>
+              """,
+            //language=xml
+            """
+              <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                <ItemGroup>
+                  <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
+                </ItemGroup>
+              </Project>
+              """,
+            spec -> spec.path("MySecond.csproj")
+          )
+        );
+    }
+
+    @Test
     void addMarkers() {
         rewriteRun(
-          spec -> spec.recipe(new DependencyVulnerabilityCheck(true)),
+          spec -> spec.recipe(new DependencyVulnerabilityCheck(true))
+            .dataTable(VulnerabilityReport.Row.class, rows -> assertThat(rows)
+              .singleElement()
+              .extracting(VulnerabilityReport.Row::getCve)
+              .isEqualTo("CVE-2010-1459")),
           xml(
             //language=xml
             """

--- a/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
@@ -114,4 +114,29 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void upgradePackageWithMultipleVulnerablePatchVersions() {
+        rewriteRun(
+          xml(
+            //language=xml
+            """
+              <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                <ItemGroup>
+                  <PackageReference Include="Microsoft.ChakraCore" Version="1.8.0" />
+                </ItemGroup>
+              </Project>
+              """,
+            //language=xml
+            """
+              <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                <ItemGroup>
+                  <PackageReference Include="Microsoft.ChakraCore" Version="1.8.5" />
+                </ItemGroup>
+              </Project>
+              """,
+            spec -> spec.path("MyFirst.csproj")
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
@@ -41,6 +41,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
               <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                 <ItemGroup>
                   <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
+                  <PackageReference Include="Microsoft.AspNetCore.Foo" Version="1.0.2" />
                 </ItemGroup>
               </Project>
               """,
@@ -49,6 +50,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
               <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                 <ItemGroup>
                   <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.4" />
+                  <PackageReference Include="Microsoft.AspNetCore.Foo" Version="1.0.2" />
                 </ItemGroup>
               </Project>
               """,

--- a/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
@@ -55,13 +55,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
               </Project>
               """,
             spec -> spec.path("MyFirst.csproj")
-          )
-        );
-    }
-
-    @Test
-    void updateSecondWithinDifferentRange() {
-        rewriteRun(
+          ),
           xml(
             //language=xml
             """

--- a/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.dependencies;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+class DependencyVulnerabilityCheckTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new DependencyVulnerabilityCheck(Boolean.TRUE));
+    }
+
+    @Test
+    @DocumentExample
+    void markVulnerability() {
+        rewriteRun(
+            xml(
+                //language=xml
+                """
+                  <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                    <ItemGroup>
+                      <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
+                    </ItemGroup>
+                  </Project>
+                  """,
+                //language=xml
+                """
+                  <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                    <ItemGroup>
+                      <!--~~(This dependency has the following vulnerabilities:
+                  CVE-2017-0247 (HIGH severity, fixed in 1.0.4) - ASP.NET Core fails to properly validate web requests
+                  CVE-2017-0248 (MODERATE severity, fixed in 1.0.4) - Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core
+                  CVE-2017-0249 (HIGH severity, fixed in 1.0.4) - High severity vulnerability that affects Microsoft.AspNetCore.Mvc
+                  CVE-2017-0256 (MODERATE severity, fixed in 1.0.4) - Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc)~~>--><PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
+                    </ItemGroup>
+                  </Project>
+                  """,
+                spec -> spec.path("MyFirst.csproj")
+            )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
@@ -26,36 +26,62 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new DependencyVulnerabilityCheck(Boolean.TRUE));
+        spec.recipe(new DependencyVulnerabilityCheck(null));
     }
 
     @Test
     @DocumentExample
-    void markVulnerability() {
+    void upgradeVulnerableDependency() {
         rewriteRun(
-            xml(
-                //language=xml
-                """
-                  <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                    <ItemGroup>
-                      <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
-                    </ItemGroup>
-                  </Project>
-                  """,
-                //language=xml
-                """
-                  <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-                    <ItemGroup>
-                      <!--~~(This dependency has the following vulnerabilities:
-                  CVE-2017-0247 (HIGH severity, fixed in 1.0.4) - ASP.NET Core fails to properly validate web requests
-                  CVE-2017-0248 (MODERATE severity, fixed in 1.0.4) - Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core
-                  CVE-2017-0249 (HIGH severity, fixed in 1.0.4) - High severity vulnerability that affects Microsoft.AspNetCore.Mvc
-                  CVE-2017-0256 (MODERATE severity, fixed in 1.0.4) - Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc)~~>--><PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
-                    </ItemGroup>
-                  </Project>
-                  """,
-                spec -> spec.path("MyFirst.csproj")
-            )
+          xml(
+            //language=xml
+            """
+              <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                <ItemGroup>
+                  <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
+                </ItemGroup>
+              </Project>
+              """,
+            //language=xml
+            """
+              <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                <ItemGroup>
+                  <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.4" />
+                </ItemGroup>
+              </Project>
+              """,
+            spec -> spec.path("MyFirst.csproj")
+          )
+        );
+    }
+
+    @Test
+    void addMarkers() {
+        rewriteRun(
+          spec -> spec.recipe(new DependencyVulnerabilityCheck(true)),
+          xml(
+            //language=xml
+            """
+              <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                <ItemGroup>
+                  <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
+                </ItemGroup>
+              </Project>
+              """,
+            //language=xml
+            """
+              <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                <ItemGroup>
+                  <!--~~(This dependency has the following vulnerabilities:
+              CVE-2017-0247 (HIGH severity, fixed in 1.0.4) - ASP.NET Core fails to properly validate web requests
+              CVE-2017-0248 (MODERATE severity, fixed in 1.0.4) - Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core
+              CVE-2017-0249 (HIGH severity, fixed in 1.0.4) - High severity vulnerability that affects Microsoft.AspNetCore.Mvc
+              CVE-2017-0256 (MODERATE severity, fixed in 1.0.4) - Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc)~~>--><PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.4" />
+                </ItemGroup>
+              </Project>
+              """,
+            spec -> spec.path("MyFirst.csproj")
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/csharp/dependencies/DependencyVulnerabilityCheckTest.java
@@ -64,7 +64,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
             """
               <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                 <ItemGroup>
-                  <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.2" />
+                  <PackageReference Include="mono" Version="1.0" />
                 </ItemGroup>
               </Project>
               """,
@@ -73,10 +73,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
               <Project ToolsVersion="4.0" DefaultTargets="FullPublish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
                 <ItemGroup>
                   <!--~~(This dependency has the following vulnerabilities:
-              CVE-2017-0247 (HIGH severity, fixed in 1.0.4) - ASP.NET Core fails to properly validate web requests
-              CVE-2017-0248 (MODERATE severity, fixed in 1.0.4) - Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Mvc.Core
-              CVE-2017-0249 (HIGH severity, fixed in 1.0.4) - High severity vulnerability that affects Microsoft.AspNetCore.Mvc
-              CVE-2017-0256 (MODERATE severity, fixed in 1.0.4) - Moderate severity vulnerability that affects Microsoft.AspNetCore.Mvc)~~>--><PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.4" />
+              CVE-2010-1459 (MODERATE severity, fixed in 2.6.4) - Mono ASP.NET View State Cross-Site Scripting (XSS) vulnerability)~~>--><PackageReference Include="mono" Version="1.0" />
                 </ItemGroup>
               </Project>
               """,

--- a/src/test/java/org/openrewrite/csharp/dependencies/trait/PackageReferenceTest.java
+++ b/src/test/java/org/openrewrite/csharp/dependencies/trait/PackageReferenceTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.dependencies.trait;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.test.RewriteTest.toRecipe;
+import static org.openrewrite.xml.Assertions.xml;
+
+class PackageReferenceTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(() -> new PackageReference.Matcher().asVisitor(ref -> ref.withVersion("3.6.1"))));
+    }
+
+    @Test
+    @DocumentExample
+    void updateVersion() {
+        rewriteRun(
+          xml(
+            //language=xml
+            """
+              <Project>
+                <ItemGroup>
+                  <PackageReference Include="Contoso.Utility.UsefulStuff" Version="3.6.0" />
+                </ItemGroup>
+              </Project>
+              """,
+            //language=xml
+            """
+              <Project>
+                <ItemGroup>
+                  <PackageReference Include="Contoso.Utility.UsefulStuff" Version="3.6.1" />
+                </ItemGroup>
+              </Project>
+              """,
+            spec -> spec.path("MyFirst.csproj")
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Add recipe to find Nuget dependency vulnerabilities

## What's your motivation?
Parity with Maven & Nodejs; bring to light vulnerable versions in use.

## Anything in particular you'd like reviewers to focus on?
Bumping dependency versions with the current trait based approach might need some work still, although this iteration can already detect vulnerable dependencies.

## Any additional context
- Continues on from https://github.com/openrewrite/rewrite-java-dependencies/pull/118
