### PR TITLE
Upgrade C# dependency versions

### DIFF
--- a/src/main/java/org/openrewrite/csharp/dependencies/UpgradeDependencyVersion.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/UpgradeDependencyVersion.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.dependencies;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.csharp.dependencies.trait.PackageReference;
+import org.openrewrite.internal.StringUtils;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class UpgradeDependencyVersion extends Recipe {
+    @Option(displayName = "Package pattern",
+            description = "Package glob pattern used to match dependencies.",
+            example = "Microsoft*")
+    String packagePattern;
+
+    @Option(displayName = "New version",
+            description = "An exact version number.",
+            example = "12.3")
+    String newVersion;
+
+    @Override
+    public String getDisplayName() {
+        return "Upgrade C# dependency versions";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Upgrades dependencies in `*.csproj` and `packages.config`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new PackageReference.Matcher().asVisitor((ref, ctx) -> {
+            if (StringUtils.matchesGlob(ref.getInclude(), packagePattern)) {
+                return ref.withVersion(newVersion);
+            }
+            return ref.getTree();
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/csharp/dependencies/trait/PackageReference.java
+++ b/src/main/java/org/openrewrite/csharp/dependencies/trait/PackageReference.java
@@ -44,7 +44,7 @@ public class PackageReference implements Trait<Xml.Tag> {
             InMemoryExecutionContext ctx = new InMemoryExecutionContext();
             tag = (Xml.Tag) new ChangeTagAttribute("//PackageReference", "Version", newVersion, this.version, null)
                     .getVisitor().visitNonNull(tag, ctx);
-            tag = (Xml.Tag) new ChangeTagAttribute("/packages/package", "version", newVersion, this.version, null)
+            tag = (Xml.Tag) new ChangeTagAttribute("//package", "version", newVersion, this.version, null)
                     .getVisitor().visitNonNull(tag, ctx);
         }
         return tag;

--- a/src/test/java/org/openrewrite/csharp/dependencies/UpgradeDependencyVersionTest.java
+++ b/src/test/java/org/openrewrite/csharp/dependencies/UpgradeDependencyVersionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.dependencies;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+class UpgradeDependencyVersionTest implements RewriteTest {
+
+    @Test
+    @DocumentExample
+    void packagesConfig() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("Microsoft.*", "2.1.2")),
+          xml(
+            //language=xml
+            """
+              <?xml version="1.0" encoding="utf-8"?>
+              <packages>
+                <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net46" />
+                <package id="WebActivatorEx" version="2.1.0" targetFramework="net46" />
+              </packages>
+              """,
+            //language=xml
+            """
+              <?xml version="1.0" encoding="utf-8"?>
+              <packages>
+                <package id="Microsoft.Web.Xdt" version="2.1.2" targetFramework="net46" />
+                <package id="WebActivatorEx" version="2.1.0" targetFramework="net46" />
+              </packages>
+              """,
+            spec -> spec.path("packages.config")
+          )
+        );
+    }
+
+    @Test
+    void csproj() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("Contoso.Utility.SomeOther*", "3.6.2")),
+          xml(
+            //language=xml
+            """
+              <Project>
+                <ItemGroup>
+                  <PackageReference Include="Contoso.Utility.UsefulStuff" Version="3.6.1" />
+                  <PackageReference Include="Contoso.Utility.SomeOtherUsefulStuff" Version="3.6.0" />
+                </ItemGroup>
+              </Project>
+              """,
+            //language=xml
+            """
+              <Project>
+                <ItemGroup>
+                  <PackageReference Include="Contoso.Utility.UsefulStuff" Version="3.6.1" />
+                  <PackageReference Include="Contoso.Utility.SomeOtherUsefulStuff" Version="3.6.2" />
+                </ItemGroup>
+              </Project>
+              """,
+            spec -> spec.path("MyFirst.csproj")
+          )
+        );
+    }
+}


### PR DESCRIPTION
This one was missing, and turns out we failed to update tags for packages.config, as we matched on the full path only.