### PR TITLE
Vulnerability check overhaul

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
@@ -34,9 +34,9 @@ import org.openrewrite.java.dependencies.internal.VersionParser;
 import org.openrewrite.java.dependencies.table.VulnerabilityReport;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.marker.CommitMessage;
-import org.openrewrite.maven.AddManagedDependency;
-import org.openrewrite.maven.MavenIsoVisitor;
-import org.openrewrite.maven.MavenVisitor;
+import org.openrewrite.maven.*;
+import org.openrewrite.maven.internal.MavenPomDownloader;
+import org.openrewrite.maven.table.MavenMetadataFailures;
 import org.openrewrite.maven.tree.*;
 import org.openrewrite.semver.LatestPatch;
 import org.openrewrite.xml.tree.Xml;
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulnerabilityCheck.Accumulator> {
+    transient MavenMetadataFailures metadataFailures = new MavenMetadataFailures(this);
     transient VersionParser versionParser = new VersionParser();
     transient VulnerabilityReport report = new VulnerabilityReport(this);
 
@@ -68,12 +69,6 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
             required = false)
     @Nullable
     Boolean overrideTransitive;
-
-    public enum AcceptableVersionDelta {
-        Patch,
-        Minor,
-        Major
-    }
 
     @Override
     public String getDisplayName() {
@@ -116,7 +111,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
         @Nullable
         private Map<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> upgradeableVulnerabilities = null;
 
-        public Map<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> upgradeableVulnerabilities(AcceptableVersionDelta delta) {
+        public Map<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> upgradeableVulnerabilities() {
             if (upgradeableVulnerabilities == null) {
                 upgradeableVulnerabilities = new LinkedHashMap<>();
                 for (Vulnerabilities vuln : projectToVulnerabilities.values()) {
@@ -124,18 +119,19 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                         ResolvedGroupArtifactVersion gav = resolvedGroupArtifactVersionSetEntry.getKey();
                         Set<MinimumDepthVulnerability> vulnerabilities = resolvedGroupArtifactVersionSetEntry.getValue();
                         upgradeableVulnerabilities.compute(gav, (k, upgradeableSoFar) -> {
-                            List<MinimumDepthVulnerability> newUpgradableVulnerabilities = vulnerabilities.stream()
+                            Set<MinimumDepthVulnerability> newUpgradableVulnerabilities = vulnerabilities.stream()
                                     .filter(it -> StringUtils.isNotEmpty(it.vulnerability.getFixedVersion()))
                                     .filter(it -> new LatestPatch(null)
                                             .isValid(gav.getVersion(), it.vulnerability.getFixedVersion()))
-                                    .collect(Collectors.toList());
+                                    .collect(Collectors.toCollection(LinkedHashSet::new));
                             if (newUpgradableVulnerabilities.isEmpty()) {
                                 return upgradeableSoFar;
                             }
                             if (upgradeableSoFar == null) {
-                                upgradeableSoFar = new LinkedHashSet<>();
+                                upgradeableSoFar = newUpgradableVulnerabilities;
+                            } else {
+                                upgradeableSoFar.addAll(newUpgradableVulnerabilities);
                             }
-                            upgradeableSoFar.addAll(newUpgradableVulnerabilities);
 
                             return upgradeableSoFar;
                         });
@@ -239,16 +235,18 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                 }
                 Tree t = tree;
                 Map<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> upgradeableVulnerabilities =
-                        acc.upgradeableVulnerabilities(AcceptableVersionDelta.Patch);
+                        acc.upgradeableVulnerabilities();
                 for (Map.Entry<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> gavToUpgradeableVulnerabilities : upgradeableVulnerabilities.entrySet()) {
                     ResolvedGroupArtifactVersion gav = gavToUpgradeableVulnerabilities.getKey();
-                    Tree t2 = new UpgradeDependencyVersion(gav.getGroupId(), gav.getArtifactId(), "latest.patch", null, overrideTransitive, null)
+                    Set<MinimumDepthVulnerability> vulnerabilities = gavToUpgradeableVulnerabilities.getValue();
+                    String versionToRequest = versionToRequest(vulnerabilities, Collections.singletonList(MavenRepository.MAVEN_CENTRAL), ctx);
+                    Tree t2 = new UpgradeDependencyVersion(gav.getGroupId(), gav.getArtifactId(), versionToRequest, null, overrideTransitive, null)
                             .getVisitor(acc.getDependencyAcc())
                             .visitNonNull(t, ctx);
                     String because = null;
                     if (t2 == t) {
-                        because = because(gavToUpgradeableVulnerabilities.getValue());
-                        t2 = new UpgradeTransitiveDependencyVersion(gav.getGroupId(), gav.getArtifactId(), "latest.patch", scope, null, null, null, because, null, null, true)
+                        because = because(vulnerabilities);
+                        t2 = new UpgradeTransitiveDependencyVersion(gav.getGroupId(), gav.getArtifactId(), versionToRequest, scope, null, null, null, because, null, null, true)
                                 .getVisitor(acc.getTransitiveAcc())
                                 .visitNonNull(t2, ctx);
                     }
@@ -256,7 +254,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
 
                     if (t != tree) {
                         if (because == null) {
-                            because = because(gavToUpgradeableVulnerabilities.getValue());
+                            because = because(vulnerabilities);
                         }
                         CommitMessage.message(t2, DependencyVulnerabilityCheck.this, because);
                     }
@@ -264,6 +262,40 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                 return t;
             }
         };
+    }
+
+    /**
+     * Of the vulnerabilities with valid upgrade paths, take the highest fixed version.
+     * See if the highest fixed version can be resolved from the available repositories.
+     * Sometimes a fix version in the database will slightly inaccurate, such as missing a suffix (milestone, timestamp, etc.).
+     * If the fix version from the database cannot be validated to exist, leave discovery up to upgrade dependency
+     * recipes by falling back to "latest.patch".
+     */
+    private String versionToRequest(Set<MinimumDepthVulnerability> vulnerabilities, List<MavenRepository> repositories, ExecutionContext ctx) {
+        Comparator<Version> vc = new StaticVersionComparator();
+        Vulnerability highestFix = vulnerabilities.stream()
+                .max(Comparator.comparing(
+                        it -> versionParser.transform(stripExtraneousVersionSuffix(it.getVulnerability().getFixedVersion())),
+                        vc))
+                .map(MinimumDepthVulnerability::getVulnerability)
+                .orElse(null);
+        if (highestFix != null) {
+            String[] groupArtifact = highestFix.getGroupArtifact().split(":");
+            String groupId = groupArtifact[0];
+            String artifactId = groupArtifact[1];
+
+            try {
+                MavenMetadata metadata = metadataFailures.insertRows(ctx, () -> new MavenPomDownloader(ctx).downloadMetadata(
+                        new GroupArtifact(groupId, artifactId), null, repositories));
+                List<String> versions = metadata.getVersioning().getVersions();
+                if (versions.contains(highestFix.getFixedVersion())) {
+                    return highestFix.getFixedVersion();
+                }
+            } catch (MavenDownloadingException e) {
+                return "latest.patch";
+            }
+        }
+        return "latest.patch";
     }
 
     @Nullable
@@ -392,6 +424,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
             }
         }
     }
+
 
     @Value
     public static class MinimumDepthVulnerability {

--- a/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
@@ -18,12 +18,10 @@ package org.openrewrite.java.dependencies;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import lombok.EqualsAndHashCode;
-import lombok.Value;
+import lombok.*;
 import lombok.experimental.NonFinal;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
-import org.openrewrite.gradle.UpgradeTransitiveDependencyVersion;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.groovy.GroovyIsoVisitor;
@@ -36,11 +34,9 @@ import org.openrewrite.java.dependencies.internal.VersionParser;
 import org.openrewrite.java.dependencies.table.VulnerabilityReport;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.marker.CommitMessage;
-import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.AddManagedDependency;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.maven.MavenVisitor;
-import org.openrewrite.maven.UpgradeDependencyVersion;
 import org.openrewrite.maven.tree.*;
 import org.openrewrite.semver.LatestPatch;
 import org.openrewrite.xml.tree.Xml;
@@ -50,8 +46,6 @@ import java.io.InputStream;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static java.util.Objects.requireNonNull;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -75,13 +69,11 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
     @Nullable
     Boolean overrideTransitive;
 
-    @Option(displayName = "Add search markers",
-            description = "Report each vulnerability as search result markers. " +
-                          "When enabled you can see which dependencies are bringing in vulnerable transitives in the diff view. " +
-                          "By default these markers are omitted, making it easier to see version upgrades within the diff.",
-            required = false)
-    @Nullable
-    Boolean addMarkers;
+    public enum AcceptableVersionDelta {
+        Patch,
+        Minor,
+        Major
+    }
 
     @Override
     public String getDisplayName() {
@@ -111,19 +103,52 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
         }));
     }
 
-    @Value
+    @Getter
+    @RequiredArgsConstructor
     public static class Accumulator {
-        Map<GroupArtifact, List<Vulnerability>> db;
-        Map<String, Vulnerabilities> projectToVulnerabilities;
-        Scope scope;
-        org.openrewrite.maven.UpgradeDependencyVersion.Accumulator mavenUdvAcc;
-        org.openrewrite.gradle.UpgradeDependencyVersion.DependencyVersionState gradleUdvAcc;
+        final Map<GroupArtifact, List<Vulnerability>> db;
+        final Scope scope;
+        final org.openrewrite.java.dependencies.UpgradeDependencyVersion.Accumulator dependencyAcc;
+        final AddManagedDependency.Scanned transitiveAcc;
+
+        Map<String, Vulnerabilities> projectToVulnerabilities = new LinkedHashMap<>();
+
+        @Nullable
+        private Map<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> upgradeableVulnerabilities = null;
+
+        public Map<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> upgradeableVulnerabilities(AcceptableVersionDelta delta) {
+            if (upgradeableVulnerabilities == null) {
+                upgradeableVulnerabilities = new LinkedHashMap<>();
+                for (Vulnerabilities vuln : projectToVulnerabilities.values()) {
+                    for (Map.Entry<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> resolvedGroupArtifactVersionSetEntry : vuln.getGavToVulnerabilities().entrySet()) {
+                        ResolvedGroupArtifactVersion gav = resolvedGroupArtifactVersionSetEntry.getKey();
+                        Set<MinimumDepthVulnerability> vulnerabilities = resolvedGroupArtifactVersionSetEntry.getValue();
+                        upgradeableVulnerabilities.compute(gav, (k, upgradeableSoFar) -> {
+                            List<MinimumDepthVulnerability> newUpgradableVulnerabilities = vulnerabilities.stream()
+                                    .filter(it -> StringUtils.isNotEmpty(it.vulnerability.getFixedVersion()))
+                                    .filter(it -> new LatestPatch(null)
+                                            .isValid(gav.getVersion(), it.vulnerability.getFixedVersion()))
+                                    .collect(Collectors.toList());
+                            if (newUpgradableVulnerabilities.isEmpty()) {
+                                return upgradeableSoFar;
+                            }
+                            if (upgradeableSoFar == null) {
+                                upgradeableSoFar = new LinkedHashSet<>();
+                            }
+                            upgradeableSoFar.addAll(newUpgradableVulnerabilities);
+
+                            return upgradeableSoFar;
+                        });
+
+                    }
+                }
+            }
+            return upgradeableVulnerabilities;
+        }
     }
 
     @Value
     public static class Vulnerabilities {
-        public static Vulnerabilities NONE = new Vulnerabilities(Collections.emptyMap());
-
         Map<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> gavToVulnerabilities;
 
         public Set<MinimumDepthVulnerability> computeIfAbsent(ResolvedGroupArtifactVersion gav, Function<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> mappingFunction) {
@@ -148,9 +173,11 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
             throw new RuntimeException(e);
         }
 
-        return new Accumulator(db, new LinkedHashMap<>(), parsedScope,
-                new org.openrewrite.maven.UpgradeDependencyVersion.Accumulator(),
-                new org.openrewrite.gradle.UpgradeDependencyVersion.DependencyVersionState());
+        return new Accumulator(db, parsedScope,
+                new UpgradeDependencyVersion("", "", "", null, null, null)
+                        .getInitialValue(ctx),
+                new UpgradeTransitiveDependencyVersion("", "", "", null, null, null, null, null, null, null, true)
+                        .getInitialValue(ctx));
     }
 
     @Override
@@ -163,11 +190,11 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                 }
                 scanMaven(acc.getDb(), acc.getProjectToVulnerabilities(), acc.getScope()).visitNonNull(tree, ctx);
                 scanGradleGroovy(acc.getDb(), acc.getProjectToVulnerabilities(), acc.getScope()).visitNonNull(tree, ctx);
-                new UpgradeDependencyVersion("", "", "", null, null, null)
-                        .getScanner(acc.getMavenUdvAcc())
+                new org.openrewrite.java.dependencies.UpgradeDependencyVersion("", "", "", null, null, null)
+                        .getScanner(acc.getDependencyAcc())
                         .visit(tree, ctx);
-                new org.openrewrite.gradle.UpgradeDependencyVersion("", "", null, null)
-                        .getScanner(acc.getGradleUdvAcc())
+                new org.openrewrite.java.dependencies.UpgradeTransitiveDependencyVersion("", "", "", null, null, null, null, null, null, null, true)
+                        .getScanner(acc.getTransitiveAcc())
                         .visit(tree, ctx);
                 return tree;
             }
@@ -207,90 +234,47 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
     public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
         return new TreeVisitor<Tree, ExecutionContext>() {
             @Override
-            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (tree == null) {
                     return null;
                 }
                 Tree t = tree;
-
-                if (t.getMarkers().findFirst(MavenResolutionResult.class).isPresent()) {
-                    Map<GroupArtifact, VersionBecause> fixes = new LinkedHashMap<>();
-                    Vulnerabilities vulnerabilities = acc.getProjectToVulnerabilities().getOrDefault(projectName(t), Vulnerabilities.NONE);
-                    if (!vulnerabilities.getGavToVulnerabilities().isEmpty()) {
-                        t = enumerateFixesMaven(vulnerabilities.getGavToVulnerabilities(), acc.getScope(), fixes).visitNonNull(t, ctx);
-                        for (Map.Entry<GroupArtifact, VersionBecause> gav : fixes.entrySet()) {
-                            Tree t2 = new UpgradeDependencyVersion(gav.getKey().getGroupId(), gav.getKey().getArtifactId(),
-                                    gav.getValue().getVersion(), null, overrideTransitive, null)
-                                    .getVisitor(acc.getMavenUdvAcc())
-                                    .visitNonNull(t, ctx);
-                            if (t == t2 && gav.getValue().isDotReleaseAmbiguous()) {
-                                t2 = new UpgradeDependencyVersion(gav.getKey().getGroupId(), gav.getKey().getArtifactId(),
-                                        gav.getValue().getVersion() + ".RELEASE", null, overrideTransitive, null)
-                                        .getVisitor(acc.getMavenUdvAcc())
-                                        .visitNonNull(t, ctx);
-                            }
-                            if (t == t2) {
-                                if (Boolean.TRUE.equals(overrideTransitive)) {
-                                    AddManagedDependency amd = new AddManagedDependency(gav.getKey().getGroupId(), gav.getKey().getArtifactId(), gav.getValue().getVersion(), null, null, null, null, null, null, null);
-                                    t2 = amd.getVisitor(amd.getInitialValue(ctx))
-                                            .visitNonNull(t, ctx);
-                                    if (t == t2 && gav.getValue().isDotReleaseAmbiguous()) {
-                                        amd = new AddManagedDependency(gav.getKey().getGroupId(), gav.getKey().getArtifactId(), gav.getValue().getVersion() + ".RELEASE", null, null, null, null, null, null, null);
-                                        t2 = amd.getVisitor(amd.getInitialValue(ctx))
-                                                .visitNonNull(t, ctx);
-                                    }
-                                    if (t != t2) {
-                                        t = CommitMessage.message(t2, DependencyVulnerabilityCheck.this, requireNonNull(gav.getValue().getBecause()));
-                                    }
-                                }
-                            } else {
-                                t = CommitMessage.message(t2, DependencyVulnerabilityCheck.this, requireNonNull(gav.getValue().getBecause()));
-                            }
-                        }
+                Map<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> upgradeableVulnerabilities =
+                        acc.upgradeableVulnerabilities(AcceptableVersionDelta.Patch);
+                for (Map.Entry<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> gavToUpgradeableVulnerabilities : upgradeableVulnerabilities.entrySet()) {
+                    ResolvedGroupArtifactVersion gav = gavToUpgradeableVulnerabilities.getKey();
+                    Tree t2 = new UpgradeDependencyVersion(gav.getGroupId(), gav.getArtifactId(), "latest.patch", null, overrideTransitive, null)
+                            .getVisitor(acc.getDependencyAcc())
+                            .visitNonNull(t, ctx);
+                    String because = null;
+                    if (t2 == t) {
+                        because = because(gavToUpgradeableVulnerabilities.getValue());
+                        t2 = new UpgradeTransitiveDependencyVersion(gav.getGroupId(), gav.getArtifactId(), "latest.patch", scope, null, null, null, because, null, null, true)
+                                .getVisitor(acc.getTransitiveAcc())
+                                .visitNonNull(t2, ctx);
                     }
-                } else if (t.getMarkers().findFirst(GradleProject.class).isPresent()) {
-                    Map<GroupArtifact, VersionBecause> fixes = new LinkedHashMap<>();
-                    Vulnerabilities vulnerabilities = acc.getProjectToVulnerabilities().getOrDefault(projectName(t), Vulnerabilities.NONE);
-                    if (!vulnerabilities.getGavToVulnerabilities().isEmpty()) {
-                        t = enumerateFixesGradleGroovy(vulnerabilities.getGavToVulnerabilities(), acc.getScope(), fixes).visitNonNull(t, ctx);
-                        for (Map.Entry<GroupArtifact, VersionBecause> gaToVb : fixes.entrySet()) {
-                            VersionBecause vb = gaToVb.getValue();
-                            Tree t2 = new org.openrewrite.gradle.UpgradeDependencyVersion(gaToVb.getKey().getGroupId(), gaToVb.getKey().getArtifactId(),
-                                    vb.getVersion(), null)
-                                    .getVisitor(acc.getGradleUdvAcc())
-                                    .visitNonNull(t, ctx);
-                            if (t == t2 && vb.isDotReleaseAmbiguous()) {
-                                t2 = new org.openrewrite.gradle.UpgradeDependencyVersion(gaToVb.getKey().getGroupId(), gaToVb.getKey().getArtifactId(),
-                                        vb.getVersion() + ".RELEASE", null)
-                                        .getVisitor(acc.getGradleUdvAcc())
-                                        .visitNonNull(t, ctx);
-                            }
-                            if (t == t2) {
-                                if (Boolean.TRUE.equals(overrideTransitive)) {
-                                    t2 = new UpgradeTransitiveDependencyVersion(gaToVb.getKey().getGroupId(), gaToVb.getKey().getArtifactId(),
-                                            vb.getVersion(), null, vb.getBecause(), null)
-                                            .getVisitor()
-                                            .visitNonNull(t, ctx);
-                                    if(t == t2 && vb.isDotReleaseAmbiguous()) {
-                                        t2 = new UpgradeTransitiveDependencyVersion(gaToVb.getKey().getGroupId(), gaToVb.getKey().getArtifactId(),
-                                                vb.getVersion() + ".RELEASE", null, vb.getBecause(), null)
-                                                .getVisitor()
-                                                .visitNonNull(t, ctx);
-                                    }
-                                    if (t != t2) {
-                                        t = CommitMessage.message(t2, DependencyVulnerabilityCheck.this, vb.getBecause());
-                                    }
-                                }
-                            } else {
-                                t = CommitMessage.message(t2, DependencyVulnerabilityCheck.this, vb.getBecause());
-                            }
+                    t = t2;
+
+                    if (t != tree) {
+                        if (because == null) {
+                            because = because(gavToUpgradeableVulnerabilities.getValue());
                         }
+                        CommitMessage.message(t2, DependencyVulnerabilityCheck.this, because);
                     }
                 }
-
                 return t;
             }
         };
+    }
+
+    @Nullable
+    private static String because(Collection<MinimumDepthVulnerability> reasons) {
+        String because = reasons.stream()
+                .map(MinimumDepthVulnerability::getVulnerability)
+                .map(Vulnerability::getCve)
+                .filter(StringUtils::isNotEmpty)
+                .collect(Collectors.joining(", "));
+        return StringUtils.isBlank(because) ? null : because;
     }
 
     private MavenVisitor<ExecutionContext> scanMaven(
@@ -361,16 +345,6 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
         };
     }
 
-    @Value
-    private static class VersionBecause {
-        String version;
-
-        @Nullable
-        String because;
-
-        boolean dotReleaseAmbiguous;
-    }
-
     private void analyzeDependency(
             Map<GroupArtifact, List<Vulnerability>> db,
             Vulnerabilities vulnerabilities,
@@ -389,7 +363,6 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                 // This inconsistency complicates dependency upgrade since we don't know which version number format to request
                 // Therefore ignore the suffix during comparison but record it so that version upgrades can try both with and without the suffix
                 // The edge case of ".RELEASE" being introduced into a version scheme between patch versions is possible but hopefully rare
-                boolean dotReleaseAmbiguous = resolvedDependency.getVersion().endsWith(".RELEASE") && !v.getFixedVersion().endsWith(".RELEASE");
                 boolean isLessThanFixed = StringUtils.isBlank(v.getFixedVersion());
                 if (!isLessThanFixed
                     && vc.compare(
@@ -415,115 +388,10 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                         }
                     }
 
-                    gavVs.add(new MinimumDepthVulnerability(resolvedDependency.getDepth(), v, dotReleaseAmbiguous));
+                    gavVs.add(new MinimumDepthVulnerability(resolvedDependency.getDepth(), v));
                 }
             }
         }
-    }
-
-    private MavenVisitor<ExecutionContext> enumerateFixesMaven(
-            Map<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> vulnerabilities,
-            Scope aScope,
-            Map<GroupArtifact, VersionBecause> fixes
-    ) {
-        return new MavenIsoVisitor<ExecutionContext>() {
-            @Override
-            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
-                if (isDependencyTag()) {
-                    ResolvedDependency resolved = findDependency(tag, aScope);
-                    if (resolved != null) {
-                        for (Map.Entry<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> vulnerabilitiesByGav : vulnerabilities.entrySet()) {
-                            ResolvedGroupArtifactVersion gav = vulnerabilitiesByGav.getKey();
-                            ResolvedDependency match = resolved.findDependency(requireNonNull(gav.getGroupId()), gav.getArtifactId());
-                            if (match != null) {
-                                boolean vulnerable = false;
-
-                                for (MinimumDepthVulnerability vDepth : vulnerabilitiesByGav.getValue()) {
-                                    Vulnerability v = vDepth.getVulnerability();
-                                    vulnerable = true;
-
-                                    GroupArtifact ga = new GroupArtifact(gav.getGroupId(), gav.getArtifactId());
-                                    String fixVersion = (fixes.get(ga) == null) ? null : fixes.get(ga).getVersion();
-                                    if (!StringUtils.isBlank(v.getFixedVersion()) &&
-                                        new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion())) {
-                                        if (fixVersion == null || new StaticVersionComparator().compare(versionParser.transform(v.getFixedVersion()), versionParser.transform(fixVersion)) > 0) {
-                                            fixes.put(ga, new VersionBecause(v.getFixedVersion(), v.getCve(), vDepth.dotReleaseAmbiguous));
-                                        }
-                                    }
-                                }
-
-                                if (vulnerable && Boolean.TRUE.equals(addMarkers)) {
-                                    return SearchResult.found(tag, "This dependency includes " + gav + " which has the following vulnerabilities:\n" +
-                                                                   vulnerabilitiesByGav.getValue().stream()
-                                                                           .map(vDepth -> {
-                                                                               Vulnerability v = vDepth.getVulnerability();
-                                                                               return v.getCve() + " (" + v.getSeverity() + " severity" +
-                                                                                      (StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion()) +
-                                                                                      ") - " + v.getSummary();
-                                                                           })
-                                                                           .collect(Collectors.joining("\n")));
-                                }
-                            }
-                        }
-                    }
-                }
-                return super.visitTag(tag, ctx);
-            }
-        };
-    }
-
-    private GroovyVisitor<ExecutionContext> enumerateFixesGradleGroovy(
-            Map<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> vulnerabilities,
-            Scope aScope,
-            Map<GroupArtifact, VersionBecause> fixes
-    ) {
-        return new GroovyIsoVisitor<ExecutionContext>() {
-            @Override
-            public G.CompilationUnit visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
-                G.CompilationUnit c = cu;
-                //noinspection OptionalGetWithoutIsPresent
-                GradleProject gp = c.getMarkers().findFirst(GradleProject.class).get();
-                for (Map.Entry<ResolvedGroupArtifactVersion, Set<MinimumDepthVulnerability>> vulnerabilitiesByGav : vulnerabilities.entrySet()) {
-                    ResolvedGroupArtifactVersion gav = vulnerabilitiesByGav.getKey();
-                    if (Boolean.TRUE.equals(addMarkers)) {
-                        c = SearchResult.found(c, "This project has the following vulnerabilities:\n" +
-                                                  vulnerabilitiesByGav.getValue().stream()
-                                                          .map(vDepth -> {
-                                                              Vulnerability v = vDepth.getVulnerability();
-                                                              return "Dependency " + gav + " has " + v.getCve() + " (" + v.getSeverity() + " severity" +
-                                                                     (StringUtils.isBlank(v.getFixedVersion()) ? "" : ", fixed in " + v.getFixedVersion()) +
-                                                                     ") - " + v.getSummary();
-                                                          })
-                                                          .collect(Collectors.joining("\n")));
-                    }
-                    for (GradleDependencyConfiguration configuration : gp.getConfigurations()) {
-                        if (scopeExcludesConfiguration(configuration, aScope) || !configuration.isCanBeResolved()) {
-                            continue;
-                        }
-                        List<ResolvedDependency> resolved = configuration.getResolved();
-                        for (ResolvedDependency resolvedDependency : resolved) {
-                            if (Objects.equals(resolvedDependency.getGroupId(), gav.getGroupId())
-                                && Objects.equals(resolvedDependency.getArtifactId(), gav.getArtifactId())) {
-
-                                for (MinimumDepthVulnerability vDepth : vulnerabilitiesByGav.getValue()) {
-                                    Vulnerability v = vDepth.getVulnerability();
-
-                                    GroupArtifact ga = new GroupArtifact(gav.getGroupId(), gav.getArtifactId());
-                                    String fixVersion = (fixes.get(ga) == null) ? null : fixes.get(ga).getVersion();
-                                    if (!StringUtils.isBlank(v.getFixedVersion()) &&
-                                        new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion())) {
-                                        if (fixVersion == null || new StaticVersionComparator().compare(versionParser.transform(v.getFixedVersion()), versionParser.transform(fixVersion)) > 0) {
-                                            fixes.put(ga, new VersionBecause(v.getFixedVersion(), v.getCve(), vDepth.dotReleaseAmbiguous));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                return c;
-            }
-        };
     }
 
     @Value
@@ -532,7 +400,6 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
         int minDepth;
 
         Vulnerability vulnerability;
-        boolean dotReleaseAmbiguous;
     }
 
     private static String stripExtraneousVersionSuffix(String version) {

--- a/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
@@ -209,8 +209,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                 for (MinimumDepthVulnerability vDepth : vulnerabilitiesByGav.getValue()) {
                     Vulnerability v = vDepth.getVulnerability();
                     ResolvedGroupArtifactVersion gav = vulnerabilitiesByGav.getKey();
-                    boolean fixWithVersionUpdateOnly = (vDepth.getMinDepth() == 0 || Boolean.TRUE.equals(overrideTransitive))
-                                                       && new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion());
+                    boolean fixWithVersionUpdateOnly = new LatestPatch(null).isValid(gav.getVersion(), v.getFixedVersion());
                     report.insertRow(ctx, new VulnerabilityReport.Row(
                             projectName,
                             v.getCve(),

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
@@ -34,6 +34,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
         spec.recipe(new DependencyVulnerabilityCheck("runtime", true));
     }
 
+    @DocumentExample
     @Test
     void gradleTransitive() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
@@ -55,10 +55,10 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
               
               dependencies {
                   constraints {
-                      runtimeOnly('io.github.classgraph:classgraph:4.8.175') {
+                      runtimeOnly('io.github.classgraph:classgraph:4.8.112') {
                           because 'CVE-2021-47621'
                       }
-                      implementation('com.fasterxml.jackson.core:jackson-databind:2.12.7.2') {
+                      implementation('com.fasterxml.jackson.core:jackson-databind:2.12.7.1') {
                           because 'CVE-2020-36518, CVE-2021-46877, CVE-2022-42003, CVE-2022-42004'
                       }
                   }
@@ -124,7 +124,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
                   }
               }
               dependencies {
-                  implementation("org.apache.logging.log4j:log4j:2.13.3")
+                  implementation("org.apache.logging.log4j:log4j:2.13.2")
               }
               """,
             spec -> spec.path("dependencies.gradle")
@@ -171,7 +171,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
                     <dependency>
                       <groupId>com.fasterxml.jackson.core</groupId>
                       <artifactId>jackson-databind</artifactId>
-                      <version>2.12.7.2</version>
+                      <version>2.12.7.1</version>
                     </dependency>
                   </dependencies>
                 </dependencyManagement>
@@ -232,7 +232,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
                   <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j</artifactId>
-                    <version>2.13.3</version>
+                    <version>2.13.2</version>
                   </dependency>
                 </dependencies>
               </project>
@@ -323,7 +323,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
                   <dependency>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
-                    <version>2.13.5</version>
+                    <version>2.13.4.2</version>
                   </dependency>
                 </dependencies>
               </project>

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.dependencies;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.dependencies.table.VulnerabilityReport;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.dependencies;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.DocumentExample;
 import org.openrewrite.java.dependencies.table.VulnerabilityReport;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -27,56 +26,19 @@ import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
+@SuppressWarnings("GroovyAssignabilityCheck")
 class DependencyVulnerabilityCheckTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new DependencyVulnerabilityCheck("runtime", true, true));
-    }
-
-    @DocumentExample
-    @Test
-    void gradle() {
-        rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()),
-          //language=groovy
-          buildGradle(
-            """
-              plugins {
-                id 'java'
-              }
-              
-              repositories {
-                  mavenCentral()
-              }
-              
-              dependencies {
-                  implementation 'org.apache.logging.log4j:log4j:2.13.1'
-              }
-              """,
-            """
-              /*~~(This project has the following vulnerabilities:
-              Dependency org.apache.logging.log4j:log4j:2.13.1 has CVE-2020-9488 (LOW severity, fixed in 2.13.2) - Improper validation of certificate with host mismatch in Apache Log4j SMTP appender)~~>*/plugins {
-                id 'java'
-              }
-              
-              repositories {
-                  mavenCentral()
-              }
-              
-              dependencies {
-                  implementation 'org.apache.logging.log4j:log4j:2.13.2'
-              }
-              """
-          )
-        );
+        spec.recipe(new DependencyVulnerabilityCheck("runtime", true));
     }
 
     @Test
     void gradleTransitive() {
         rewriteRun(
           spec -> spec.beforeRecipe(withToolingApi())
-            .recipe(new DependencyVulnerabilityCheck(null, true, false)),
+            .recipe(new DependencyVulnerabilityCheck(null, true)),
           //language=groovy
           buildGradle(
             """
@@ -93,11 +55,11 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
               
               dependencies {
                   constraints {
-                      runtimeOnly('io.github.classgraph:classgraph:4.8.112') {
+                      runtimeOnly('io.github.classgraph:classgraph:4.8.175') {
                           because 'CVE-2021-47621'
                       }
-                      implementation('com.fasterxml.jackson.core:jackson-databind:2.12.7.1') {
-                          because 'CVE-2022-42003'
+                      implementation('com.fasterxml.jackson.core:jackson-databind:2.12.7.2') {
+                          because 'CVE-2020-36518, CVE-2021-46877, CVE-2022-42003, CVE-2022-42004'
                       }
                   }
               
@@ -109,9 +71,80 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
     }
 
     @Test
+    void milestoneVersion() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new DependencyVulnerabilityCheck(null, true)),
+          //language=groovy
+          buildGradle(
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+              
+              dependencies {
+                  implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.0-M1'
+              }
+              """,
+            """
+              plugins { id 'java' }
+              repositories { mavenCentral() }
+              
+              dependencies {
+                  implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.27'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dependenciesBlockInFreestandingScript() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()),
+          //language=groovy
+          buildGradle(
+            """
+              repositories {
+                  mavenLocal()
+                  mavenCentral()
+                  maven {
+                     url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+                  }
+              }
+              dependencies {
+                  implementation("org.apache.logging.log4j:log4j:2.13.1")
+              }
+              """,
+            """
+              repositories {
+                  mavenLocal()
+                  mavenCentral()
+                  maven {
+                     url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+                  }
+              }
+              dependencies {
+                  implementation("org.apache.logging.log4j:log4j:2.13.3")
+              }
+              """,
+            spec -> spec.path("dependencies.gradle")
+          ),
+          //language=groovy
+          buildGradle(
+            """
+              plugins {
+                  id("java")
+              }
+              apply from: 'dependencies.gradle'
+              """
+          )
+        );
+    }
+
+    @Test
     void mavenTransitive() {
         rewriteRun(
-          spec -> spec.recipe(new DependencyVulnerabilityCheck(null, true, false)),
+          spec -> spec.recipe(new DependencyVulnerabilityCheck(null, true)),
           //language=xml
           pomXml(
             """
@@ -138,7 +171,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
                     <dependency>
                       <groupId>com.fasterxml.jackson.core</groupId>
                       <artifactId>jackson-databind</artifactId>
-                      <version>2.12.7.1</version>
+                      <version>2.12.7.2</version>
                     </dependency>
                   </dependencies>
                 </dependencyManagement>
@@ -191,19 +224,15 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
                 <artifactId>my-app</artifactId>
                 <version>1</version>
                 <dependencies>
-                  <!--~~(This dependency includes org.springframework.security:spring-security-core:4.2.13.RELEASE which has the following vulnerabilities:
-              CVE-2022-22978 (CRITICAL severity, fixed in 5.4.11) - Authorization bypass in Spring Security
-              CVE-2024-22257 (HIGH severity, fixed in 5.7.12) - Erroneous authentication pass in Spring Security
-              CVE-2020-5408 (MODERATE severity, fixed in 4.2.16) - Insufficient Entropy in Spring Security)~~>--><dependency>
+                  <dependency>
                     <groupId>org.springframework.security</groupId>
                     <artifactId>spring-security-core</artifactId>
-                    <version>4.2.16.RELEASE</version>
+                    <version>4.2.20.RELEASE</version>
                   </dependency>
-                  <!--~~(This dependency includes org.apache.logging.log4j:log4j:2.13.1 which has the following vulnerabilities:
-              CVE-2020-9488 (LOW severity, fixed in 2.13.2) - Improper validation of certificate with host mismatch in Apache Log4j SMTP appender)~~>--><dependency>
+                  <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j</artifactId>
-                    <version>2.13.2</version>
+                    <version>2.13.3</version>
                   </dependency>
                 </dependencies>
               </project>
@@ -217,7 +246,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
     void mavenSnakeyamlMajorMinor() {
         rewriteRun(
           spec -> spec
-            .recipe(new DependencyVulnerabilityCheck("compile", false, false)),
+            .recipe(new DependencyVulnerabilityCheck("compile", false)),
           //language=xml
           pomXml(
             """
@@ -262,7 +291,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
     void mavenJacksonMajorMinorPatch() {
         rewriteRun(
           spec -> spec
-            .recipe(new DependencyVulnerabilityCheck("compile", false, false)),
+            .recipe(new DependencyVulnerabilityCheck("compile", false)),
           //language=xml
           pomXml(
             """
@@ -294,7 +323,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
                   <dependency>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
-                    <version>2.13.4.2</version>
+                    <version>2.13.5</version>
                   </dependency>
                 </dependencies>
               </project>


### PR DESCRIPTION
Overhaul DependencyVulnerabilityCheck.

Enhancements and fixes include:
- Can now upgrade dependency versions in freestanding gradle scripts
- Can now upgrade dependency versions in gradle.properties
- Fixes upgrading dependencies with version suffixes like "M1"
- Validates accuracy of fix versions, looking up an appropriate version when Works around inaccurate fix versions in the database
- Fix data table marking CVEs fixable via transitive dependency upgrades as "not fixable with version update only". This under-reporting was a holdover from before this recipe supported transitive dependency upgrades.
- Eliminated the option to add search markers. Data table is a much more useful and actionable way of viewing results.