### PR TITLE
Add `unlessUsing` property to RemoveDependency recipe

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[src/test*/java/**.java]
+indent_size = 4
+ij_continuation_indent_size = 2

--- a/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
@@ -24,19 +24,24 @@ import org.openrewrite.Recipe;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Collections.emptyList;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class RemoveDependency extends Recipe {
     @Option(displayName = "Group ID",
-        description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",
-        example = "com.fasterxml.jackson*")
+            description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",
+            example = "com.fasterxml.jackson*")
     String groupId;
 
     @Option(displayName = "Artifact ID",
-        description = "The second part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",
-        example = "jackson-module*")
+            description = "The second part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",
+            example = "jackson-module*")
     String artifactId;
+
+    @Option(displayName = "Unless using", description = "If a dependency is used in the code, do not remove it.")
+    @Nullable
+    Boolean unlessUsing;
 
     // Gradle only parameter
     @Option(displayName = "The dependency configuration", description = "The dependency configuration to remove from.", example = "api", required = false)
@@ -45,11 +50,11 @@ public class RemoveDependency extends Recipe {
 
     // Maven only parameter
     @Option(displayName = "Scope",
-        description = "Only remove dependencies if they are in this scope. If 'runtime', this will" +
-                      "also remove dependencies in the 'compile' scope because 'compile' dependencies are part of the runtime dependency set",
-        valid = {"compile", "test", "runtime", "provided"},
-        example = "compile",
-        required = false)
+            description = "Only remove dependencies if they are in this scope. If 'runtime', this will" +
+                    "also remove dependencies in the 'compile' scope because 'compile' dependencies are part of the runtime dependency set",
+            valid = {"compile", "test", "runtime", "provided"},
+            example = "compile",
+            required = false)
     @Nullable
     String scope;
 
@@ -61,7 +66,7 @@ public class RemoveDependency extends Recipe {
     @Override
     public String getDescription() {
         return "For Gradle project, removes a single dependency from the dependencies section of the `build.gradle`.\n" +
-               "For Maven project, removes a single dependency from the <dependencies> section of the pom.xml.";
+                "For Maven project, removes a single dependency from the <dependencies> section of the pom.xml.";
     }
 
     org.openrewrite.gradle.@Nullable RemoveDependency removeGradleDependency;
@@ -69,12 +74,14 @@ public class RemoveDependency extends Recipe {
     org.openrewrite.maven.@Nullable RemoveDependency removeMavenDependency;
 
     public RemoveDependency(
-        String groupId,
-        String artifactId,
-        @Nullable String configuration,
-        @Nullable String scope) {
+            String groupId,
+            String artifactId,
+            @Nullable Boolean unlessUsing,
+            @Nullable String configuration,
+            @Nullable String scope) {
         this.groupId = groupId;
         this.artifactId = artifactId;
+        this.unlessUsing = unlessUsing;
         this.configuration = configuration;
         this.scope = scope;
         removeGradleDependency = new org.openrewrite.gradle.RemoveDependency(groupId, artifactId, configuration);
@@ -83,6 +90,10 @@ public class RemoveDependency extends Recipe {
 
     @Override
     public List<Recipe> getRecipeList() {
+        if (Boolean.TRUE.equals(unlessUsing)) {
+            // logic to check if code uses the lib, if so ->
+            return emptyList();
+        }
         return Arrays.asList(removeGradleDependency, removeMavenDependency);
     }
 }

--- a/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
@@ -38,19 +38,25 @@ public class RemoveDependency extends ScanningRecipe<AtomicBoolean> {
             example = "jackson-module*")
     String artifactId;
 
-    @Option(displayName = "Unless using", description = "If a dependency is used in the code, do not remove it.", example = "org.aspectj.lang.*")
+    @Option(displayName = "Unless using",
+            description = "Do not remove if type is in use. Supports glob expressions.",
+            example = "org.aspectj.lang.*",
+            required = false)
     @Nullable
     String unlessUsing;
 
     // Gradle only parameter
-    @Option(displayName = "The dependency configuration", description = "The dependency configuration to remove from.", example = "api", required = false)
+    @Option(displayName = "The dependency configuration",
+            description = "The dependency configuration to remove from.",
+            example = "api",
+            required = false)
     @Nullable
     String configuration;
 
     // Maven only parameter
     @Option(displayName = "Scope",
             description = "Only remove dependencies if they are in this scope. If 'runtime', this will" +
-                    "also remove dependencies in the 'compile' scope because 'compile' dependencies are part of the runtime dependency set",
+                          "also remove dependencies in the 'compile' scope because 'compile' dependencies are part of the runtime dependency set",
             valid = {"compile", "test", "runtime", "provided"},
             example = "compile",
             required = false)
@@ -65,7 +71,7 @@ public class RemoveDependency extends ScanningRecipe<AtomicBoolean> {
     @Override
     public String getDescription() {
         return "For Gradle project, removes a single dependency from the dependencies section of the `build.gradle`.\n" +
-                "For Maven project, removes a single dependency from the <dependencies> section of the pom.xml.";
+               "For Maven project, removes a single dependency from the <dependencies> section of the pom.xml.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
@@ -28,7 +28,7 @@ import static java.util.Collections.emptyList;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class RemoveDependency extends Recipe {
+public class RemoveDependency extends Recipe { // TODO Extend ScanningRecipe instead
     @Option(displayName = "Group ID",
             description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",
             example = "com.fasterxml.jackson*")
@@ -39,9 +39,9 @@ public class RemoveDependency extends Recipe {
             example = "jackson-module*")
     String artifactId;
 
-    @Option(displayName = "Unless using", description = "If a dependency is used in the code, do not remove it.")
+    @Option(displayName = "Unless using", description = "If a dependency is used in the code, do not remove it.", example = "org.aspectj.lang.*")
     @Nullable
-    Boolean unlessUsing;
+    String unlessUsing;
 
     // Gradle only parameter
     @Option(displayName = "The dependency configuration", description = "The dependency configuration to remove from.", example = "api", required = false)
@@ -76,7 +76,7 @@ public class RemoveDependency extends Recipe {
     public RemoveDependency(
             String groupId,
             String artifactId,
-            @Nullable Boolean unlessUsing,
+            @Nullable String unlessUsing,
             @Nullable String configuration,
             @Nullable String scope) {
         this.groupId = groupId;
@@ -88,12 +88,15 @@ public class RemoveDependency extends Recipe {
         removeMavenDependency = new org.openrewrite.maven.RemoveDependency(groupId, artifactId, scope);
     }
 
+    // TODO Provide a scanner that looks across java sources to see if `unlessUsing` is used
+    // Optionally look for use in the correct scope and submodule, but for do-no-harm v1 can skip that for now
+
+
+    // TODO remove this method, and instead override getVisitor, as the scanning condition is not evaluated for getRecipeList
     @Override
     public List<Recipe> getRecipeList() {
-        if (Boolean.TRUE.equals(unlessUsing)) {
-            // logic to check if code uses the lib, if so ->
-            return emptyList();
-        }
         return Arrays.asList(removeGradleDependency, removeMavenDependency);
     }
+
+    // TODO override getVisitor that only calls out to removeGradleDependency or removeMavenDependency if the scanning condition is met
 }

--- a/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
@@ -77,9 +77,8 @@ public class RemoveDependency extends ScanningRecipe<AtomicBoolean> {
         return new AtomicBoolean(false);
     }
 
-    org.openrewrite.gradle.@Nullable RemoveDependency removeGradleDependency;
-
-    org.openrewrite.maven.@Nullable RemoveDependency removeMavenDependency;
+    org.openrewrite.gradle.RemoveDependency removeGradleDependency;
+    org.openrewrite.maven.RemoveDependency removeMavenDependency;
 
     public RemoveDependency(
             String groupId,
@@ -125,18 +124,17 @@ public class RemoveDependency extends ScanningRecipe<AtomicBoolean> {
             final TreeVisitor<?, ExecutionContext> mavenRemoveDep = removeMavenDependency.getVisitor();
 
             @Override
-            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-                if (!(tree instanceof SourceFile)) {
-                    return tree;
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof SourceFile) {
+                    SourceFile sf = (SourceFile) tree;
+                    if (gradleRemoveDep.isAcceptable(sf, ctx)) {
+                        return gradleRemoveDep.visitNonNull(tree, ctx);
+                    }
+                    if (mavenRemoveDep.isAcceptable(sf, ctx)) {
+                        return mavenRemoveDep.visitNonNull(tree, ctx);
+                    }
                 }
-                SourceFile sf = (SourceFile) tree;
-                if (gradleRemoveDep.isAcceptable(sf, ctx)) {
-                    return gradleRemoveDep.visitNonNull(tree, ctx);
-                }
-                if (mavenRemoveDep.isAcceptable(sf, ctx)) {
-                    return mavenRemoveDep.visitNonNull(tree, ctx);
-                }
-                return sf;
+                return tree;
             }
         };
     }

--- a/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
@@ -24,8 +24,6 @@ import org.openrewrite.Recipe;
 import java.util.Arrays;
 import java.util.List;
 
-import static java.util.Collections.emptyList;
-
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class RemoveDependency extends Recipe { // TODO Extend ScanningRecipe instead

--- a/src/test/java/org/openrewrite/.editorconfig
+++ b/src/test/java/org/openrewrite/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/src/test/java/org/openrewrite/java/dependencies/RemoveDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RemoveDependencyTest.java
@@ -139,7 +139,7 @@ class RemoveDependencyTest implements RewriteTest {
                 }
                 """
             ))
-            .recipe(new RemoveDependency("org.aspectj", "aspectjrt", "org.aspectj.lang.annotation.*", null, null)),
+            .recipe(new RemoveDependency("org.aspectj", "aspectjrt", "org.aspectj.lang.annotation *", null, null)),
           mavenProject("example",
             //language=java
             srcMainJava(

--- a/src/test/java/org/openrewrite/java/dependencies/RemoveDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RemoveDependencyTest.java
@@ -30,18 +30,18 @@ class RemoveDependencyTest implements RewriteTest {
     void removeGradleDependencyUsingStringNotationWithExclusion() {
         rewriteRun(
           spec -> spec.beforeRecipe(withToolingApi())
-            .recipe(new RemoveDependency("org.springframework.boot", "spring-boot*", null, null)),
+            .recipe(new RemoveDependency("org.springframework.boot", "spring-boot*", false, null, null)),
           //language=groovy
           buildGradle(
             """
               plugins {
                   id 'java-library'
               }
-                            
+
               repositories {
                   mavenCentral()
               }
-                            
+
               dependencies {
                   implementation("org.springframework.boot:spring-boot-starter-web:2.7.0") {
                       exclude group: "junit"
@@ -53,11 +53,11 @@ class RemoveDependencyTest implements RewriteTest {
               plugins {
                   id 'java-library'
               }
-                            
+
               repositories {
                   mavenCentral()
               }
-                            
+
               dependencies {
                   testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"
               }
@@ -70,17 +70,17 @@ class RemoveDependencyTest implements RewriteTest {
     @Test
     void removeMavenDependency() {
         rewriteRun(
-          spec -> spec.recipe(new RemoveDependency("junit", "junit", null, null)),
+          spec -> spec.recipe(new RemoveDependency("junit", "junit", false, null, null)),
           //language=xml
           pomXml(
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -99,11 +99,11 @@ class RemoveDependencyTest implements RewriteTest {
             """
               <project>
                 <modelVersion>4.0.0</modelVersion>
-                
+
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                
+
                 <dependencies>
                   <dependency>
                     <groupId>com.google.guava</groupId>
@@ -112,6 +112,33 @@ class RemoveDependencyTest implements RewriteTest {
                   </dependency>
                 </dependencies>
               </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveDependencyIfItIsUsedAndUnlessUsingIsTrue() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new RemoveDependency("org.springframework.boot", "spring-boot*", true, null, null)),
+          //language=groovy
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+              
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation("org.springframework.boot:spring-boot-starter-web:2.7.0") {
+                      exclude group: "junit"
+                  }
+                  testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"
+              }
               """
           )
         );


### PR DESCRIPTION
## What's changed?
Add an `unlessUsing` property to the RemoveDependency recipe.

## What's your motivation?
Sometimes you want to remove a dependency, unless it is used by the code.

- Fixes https://github.com/openrewrite/rewrite-java-dependencies/issues/11

## Have you considered any alternatives or workarounds?
A workaround is just to run current recipe and after migration see if the code still compiles. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
