### PR TITLE
Respect `overrideTransitive=false` in `DependencyVulnerabilityCheck`

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
+++ b/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java
@@ -264,7 +264,7 @@ public class DependencyVulnerabilityCheck extends ScanningRecipe<DependencyVulne
                             .getVisitor(acc.getDependencyAcc())
                             .visitNonNull(t, ctx);
                     String because = null;
-                    if (t2 == t) {
+                    if (t2 == t && overrideTransitive != null && overrideTransitive) {
                         because = because(vulnerabilities);
                         t2 = new UpgradeTransitiveDependencyVersion(gav.getGroupId(), gav.getArtifactId(), versionToRequest, scope, null, null, null, because, null, null, true)
                                 .getVisitor(acc.getTransitiveAcc())

--- a/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheckTest.java
@@ -46,7 +46,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
             """
               plugins { id 'java' }
               repositories { mavenCentral() }
-              
+
               dependencies {
                   implementation 'org.openrewrite:rewrite-java:7.0.0'
               }
@@ -54,7 +54,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
             """
               plugins { id 'java' }
               repositories { mavenCentral() }
-              
+
               dependencies {
                   constraints {
                       runtimeOnly('io.github.classgraph:classgraph:4.8.112') {
@@ -64,7 +64,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
                           because 'CVE-2020-36518, CVE-2021-46877, CVE-2022-42003, CVE-2022-42004'
                       }
                   }
-              
+
                   implementation 'org.openrewrite:rewrite-java:7.0.0'
               }
               """
@@ -82,7 +82,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
             """
               plugins { id 'java' }
               repositories { mavenCentral() }
-              
+
               dependencies {
                   implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.0-M1'
               }
@@ -90,7 +90,7 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
             """
               plugins { id 'java' }
               repositories { mavenCentral() }
-              
+
               dependencies {
                   implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.27'
               }
@@ -177,6 +177,30 @@ class DependencyVulnerabilityCheckTest implements RewriteTest {
                     </dependency>
                   </dependencies>
                 </dependencyManagement>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.openrewrite</groupId>
+                    <artifactId>rewrite-java</artifactId>
+                    <version>7.0.0</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void mavenOverrideTransitiveDisabledByDefault() {
+        rewriteRun(
+          spec -> spec.recipe(new DependencyVulnerabilityCheck(null, null)),
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
                 <dependencies>
                   <dependency>
                     <groupId>org.openrewrite</groupId>


### PR DESCRIPTION
## What's changed?
Check the value of `overrideTransitive` before bumping transitive dependency version. 

## What's your motivation?
Aligns with the documented option.
https://github.com/openrewrite/rewrite-java-dependencies/blob/b61703e27e43ab4fb93abbef10e6c6e43701e7fd/src/main/java/org/openrewrite/java/dependencies/DependencyVulnerabilityCheck.java#L65-L71

## Anything in particular you'd like reviewers to focus on?
Would we perhaps want to make overrideTransitive opt-out, as opposed to opt-in? Would show more results by default.