### PR TITLE
Remove ``@Nullable` from VersionParser

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/internal/VersionParser.java
+++ b/src/main/java/org/openrewrite/java/dependencies/internal/VersionParser.java
@@ -16,8 +16,6 @@
 
 package org.openrewrite.java.dependencies.internal;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +27,7 @@ public class VersionParser {
     public VersionParser() {
     }
 
-    public @Nullable Version transform(String original) {
+    public Version transform(String original) {
         return cache.computeIfAbsent(original, this::parse);
     }
 

--- a/src/main/java/org/openrewrite/java/dependencies/internal/package-info.java
+++ b/src/main/java/org/openrewrite/java/dependencies/internal/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+@NonNullFields
+package org.openrewrite.java.dependencies.internal;
+
+import org.jspecify.annotations.NullMarked;
+import org.openrewrite.internal.lang.NonNullFields;


### PR DESCRIPTION
## What's changed?
Remove nullable annotation VersionParser. 

## What's your motivation?
Annotation is wrong, the transform function cannot return null.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
