### PR TITLE
refactor: Use a standard name for `ExecutionContext`

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/ChangeDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/ChangeDependency.java
@@ -111,8 +111,8 @@ public class ChangeDependency extends Recipe {
                     overrideManagedVersion).getVisitor();
 
             @Override
-            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
-                return mavenVisitor.isAcceptable(sourceFile, executionContext) || gradleVisitor.isAcceptable(sourceFile, executionContext);
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                return mavenVisitor.isAcceptable(sourceFile, ctx) || gradleVisitor.isAcceptable(sourceFile, ctx);
             }
 
             @Override

--- a/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java
@@ -128,8 +128,8 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<AddManage
         return new TreeVisitor<Tree, ExecutionContext>() {
 
             @Override
-            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
-                return gradleUDV.isAcceptable(sourceFile, executionContext) || mavenUTDV.isAcceptable(sourceFile, executionContext);
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                return gradleUDV.isAcceptable(sourceFile, ctx) || mavenUTDV.isAcceptable(sourceFile, ctx);
             }
 
             @Override


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.recipes.ExecutionContextParameterName?organizationId=T3BlblJld3JpdGU%3D