### PR TITLE
Adding missing license information

### DIFF
--- a/src/test/java/org/openrewrite/java/dependencies/internal/StaticVersionComparatorTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/internal/StaticVersionComparatorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.dependencies.internal;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## What's changed?

Adding missing license information by running `./gradlew licenseFormat`

## What's your motivation?
Fixing broken CI: https://github.com/openrewrite/rewrite-java-dependencies/actions/runs/14089488544