### PR TITLE
Adding recipe to return minimum JUnit version

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumDependencyVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumDependencyVersion.java
@@ -129,7 +129,6 @@ public class FindMinimumDependencyVersion extends ScanningRecipe<Map<GroupArtifa
         return applyMarkersForLocatedGavs(acc, dependenciesInUse);
     }
 
-    @NotNull
     static TreeVisitor<?, ExecutionContext> applyMarkersForLocatedGavs(Map<GroupArtifact, ResolvedGroupArtifactVersion> acc, DependenciesInUse dependenciesInUse) {
         return Preconditions.check(Preconditions.or(new IsBuildGradle<>(), new FindMavenProject().getVisitor()), new TreeVisitor<Tree, ExecutionContext>() {
             @Override

--- a/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumDependencyVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumDependencyVersion.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.dependencies.search;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.IsBuildGradle;
@@ -125,6 +126,11 @@ public class FindMinimumDependencyVersion extends ScanningRecipe<Map<GroupArtifa
 
         acc.entrySet().removeIf(e -> !e.getValue().getVersion().equals(minimumVersion));
 
+        return applyMarkersForLocatedGavs(acc, dependenciesInUse);
+    }
+
+    @NotNull
+    static TreeVisitor<?, ExecutionContext> applyMarkersForLocatedGavs(Map<GroupArtifact, ResolvedGroupArtifactVersion> acc, DependenciesInUse dependenciesInUse) {
         return Preconditions.check(Preconditions.or(new IsBuildGradle<>(), new FindMavenProject().getVisitor()), new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumDependencyVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumDependencyVersion.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.dependencies.search;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.IsBuildGradle;

--- a/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumJUnitVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumJUnitVersion.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.dependencies.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
+import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.java.dependencies.internal.StaticVersionComparator;
+import org.openrewrite.java.dependencies.internal.VersionParser;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.maven.table.DependenciesInUse;
+import org.openrewrite.maven.tree.GroupArtifact;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.openrewrite.java.dependencies.search.FindMinimumDependencyVersion.applyMarkersForLocatedGavs;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class FindMinimumJUnitVersion extends ScanningRecipe<Map<GroupArtifact, ResolvedGroupArtifactVersion>> {
+    transient DependenciesInUse dependenciesInUse = new DependenciesInUse(this);
+
+    @Option(displayName = "Version",
+            description = "Determine if the provided version is the minimum JUnit version. " +
+                          "If both JUnit 4 and JUnit 5 are present, the minimum version is JUnit 4. " +
+                          "If only one version is present, that version is the minimum version.",
+            example = "4",
+            valid = {"4", "5"},
+            required = false)
+    @Nullable
+    String minimumVersion;
+
+
+    @Override
+    public String getDisplayName() {
+        return "Find minimum JUnit version";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A recipe to find the minimum version of JUnit dependencies. " +
+               "It will search for JUnit 4 and JUnit 5 dependencies in the project. " +
+               "If both versions are found, it will return the minimum version of JUnit 4.";
+    }
+
+    @Override
+    public Map<GroupArtifact, ResolvedGroupArtifactVersion> getInitialValue(ExecutionContext ctx) {
+        return new HashMap<>();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Map<GroupArtifact, ResolvedGroupArtifactVersion> acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree == null) {
+                    return null;
+                }
+                VersionParser versionParser = new VersionParser();
+                Markers m = tree.getMarkers();
+                m.findFirst(GradleProject.class).ifPresent(gradle -> {
+                    for (GradleDependencyConfiguration conf : gradle.getConfigurations()) {
+                        collectionJUnit4(versionParser, conf.getResolved(), acc);
+                        collectionJUnit5(versionParser, conf.getResolved(), acc);
+                    }
+                });
+                m.findFirst(MavenResolutionResult.class).ifPresent(maven -> {
+                    for (List<ResolvedDependency> resolved : maven.getDependencies().values()) {
+                        collectionJUnit4(versionParser, resolved, acc);
+                        collectionJUnit5(versionParser, resolved, acc);
+                    }
+                });
+                return tree;
+            }
+        };
+    }
+
+    private boolean isResolvedGroupArtifactVersion(ResolvedGroupArtifactVersion resolvedGroupArtifactVersion, String groupName, String artifactName) {
+        return resolvedGroupArtifactVersion.getArtifactId().equals(artifactName) &&
+               resolvedGroupArtifactVersion.getGroupId().equals(groupName);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Map<GroupArtifact, ResolvedGroupArtifactVersion> acc) {
+        boolean hasJUnit4 = acc.values().stream().anyMatch(resolvedGroupArtifactVersion -> isResolvedGroupArtifactVersion(resolvedGroupArtifactVersion, "junit", "junit"));
+        boolean hasJUnit5 = acc.values().stream().anyMatch(resolvedGroupArtifactVersion -> isResolvedGroupArtifactVersion(resolvedGroupArtifactVersion, "org.junit.jupiter", "junit-jupiter-api"));
+        if (Objects.equals(minimumVersion, "4")) {
+            if (hasJUnit4) {
+                acc.entrySet().removeIf(e -> !isResolvedGroupArtifactVersion(e.getValue(), "junit", "junit"));
+            } else {
+                return TreeVisitor.noop();
+            }
+        } else if (Objects.equals(minimumVersion, "5")) {
+            if (hasJUnit4) {
+                return TreeVisitor.noop();
+            } else {
+                acc.entrySet().removeIf(e -> !isResolvedGroupArtifactVersion(e.getValue(), "org.junit.jupiter", "junit-jupiter-api"));
+            }
+        } else {
+            if (hasJUnit4 && hasJUnit5) {
+                acc.entrySet().removeIf(e -> !isResolvedGroupArtifactVersion(e.getValue(), "junit", "junit"));
+            }
+        }
+
+        return applyMarkersForLocatedGavs(acc, dependenciesInUse);
+    }
+
+    private void collectionJUnit5(VersionParser versionParser, List<ResolvedDependency> resolved,
+                                  Map<GroupArtifact, ResolvedGroupArtifactVersion> acc) {
+        StaticVersionComparator versionComparator = new StaticVersionComparator();
+        for (ResolvedDependency dep : resolved) {
+            if (StringUtils.matchesGlob(dep.getGroupId(), "org.junit.jupiter") &&
+                StringUtils.matchesGlob(dep.getArtifactId(), "junit-jupiter-api")) {
+                acc.merge(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()),
+                        dep.getGav(), (d1, d2) -> versionComparator.compare(
+                                versionParser.transform(d1.getVersion()),
+                                versionParser.transform(d2.getVersion())) < 0 ?
+                                d1 : d2);
+            }
+        }
+    }
+
+    private void collectionJUnit4(VersionParser versionParser, List<ResolvedDependency> resolved,
+                                  Map<GroupArtifact, ResolvedGroupArtifactVersion> acc) {
+        StaticVersionComparator versionComparator = new StaticVersionComparator();
+        for (ResolvedDependency dep : resolved) {
+            if (StringUtils.matchesGlob(dep.getGroupId(), "junit") &&
+                StringUtils.matchesGlob(dep.getArtifactId(), "junit")) {
+                acc.merge(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()),
+                        dep.getGav(), (d1, d2) -> versionComparator.compare(
+                                versionParser.transform(d1.getVersion()),
+                                versionParser.transform(d2.getVersion())) < 0 ?
+                                d1 : d2);
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumJUnitVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumJUnitVersion.java
@@ -128,27 +128,21 @@ public class FindMinimumJUnitVersion extends ScanningRecipe<Map<GroupArtifact, R
         return applyMarkersForLocatedGavs(acc, dependenciesInUse);
     }
 
-    private void collectionJUnit5(VersionParser versionParser, List<ResolvedDependency> resolved,
-                                  Map<GroupArtifact, ResolvedGroupArtifactVersion> acc) {
-        StaticVersionComparator versionComparator = new StaticVersionComparator();
-        for (ResolvedDependency dep : resolved) {
-            if (StringUtils.matchesGlob(dep.getGroupId(), "org.junit.jupiter") &&
-                StringUtils.matchesGlob(dep.getArtifactId(), "junit-jupiter-api")) {
-                acc.merge(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()),
-                        dep.getGav(), (d1, d2) -> versionComparator.compare(
-                                versionParser.transform(d1.getVersion()),
-                                versionParser.transform(d2.getVersion())) < 0 ?
-                                d1 : d2);
-            }
-        }
-    }
-
     private void collectionJUnit4(VersionParser versionParser, List<ResolvedDependency> resolved,
                                   Map<GroupArtifact, ResolvedGroupArtifactVersion> acc) {
+        collectVersion(versionParser, resolved, "junit", "junit", acc);
+    }
+
+    private void collectionJUnit5(VersionParser versionParser, List<ResolvedDependency> resolved,
+                                  Map<GroupArtifact, ResolvedGroupArtifactVersion> acc) {
+        collectVersion(versionParser, resolved, "org.junit.jupiter", "junit-jupiter-api", acc);
+    }
+
+    private static void collectVersion(VersionParser versionParser, List<ResolvedDependency> resolved, String groupIdPattern, String artifactIdPattern, Map<GroupArtifact, ResolvedGroupArtifactVersion> acc) {
         StaticVersionComparator versionComparator = new StaticVersionComparator();
         for (ResolvedDependency dep : resolved) {
-            if (StringUtils.matchesGlob(dep.getGroupId(), "junit") &&
-                StringUtils.matchesGlob(dep.getArtifactId(), "junit")) {
+            if (StringUtils.matchesGlob(dep.getGroupId(), groupIdPattern) &&
+                    StringUtils.matchesGlob(dep.getArtifactId(), artifactIdPattern)) {
                 acc.merge(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()),
                         dep.getGav(), (d1, d2) -> versionComparator.compare(
                                 versionParser.transform(d1.getVersion()),
@@ -157,5 +151,4 @@ public class FindMinimumJUnitVersion extends ScanningRecipe<Map<GroupArtifact, R
             }
         }
     }
-
 }

--- a/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumJUnitVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/FindMinimumJUnitVersion.java
@@ -62,8 +62,15 @@ public class FindMinimumJUnitVersion extends ScanningRecipe<Map<GroupArtifact, R
     @Override
     public String getDescription() {
         return "A recipe to find the minimum version of JUnit dependencies. " +
+               "This recipe is designed to return the minimum version of JUnit in a project. " +
                "It will search for JUnit 4 and JUnit 5 dependencies in the project. " +
-               "If both versions are found, it will return the minimum version of JUnit 4.";
+               "If both versions are found, it will return the minimum version of JUnit 4.\n" +
+               "If a minimumVersion is provided, the recipe will search to see if " +
+               "the minimum version of JUnit used by the project is no lower than the minimumVersion.\n" +
+               "For example: if the minimumVersion is 4, and the project has JUnit 4.12 and JUnit 5.7, " +
+               "the recipe will return JUnit 4.12. If the project has only JUnit 5.7, the recipe will return JUnit 5.7.\n" +
+               "Another example: if the minimumVersion is 5, and the project has JUnit 4.12 and JUnit 5.7, " +
+               "the recipe will not return any results.";
     }
 
     @Override

--- a/src/test/java/org/openrewrite/java/dependencies/search/FindMinimumJunitVersionTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/FindMinimumJunitVersionTest.java
@@ -1,0 +1,511 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.dependencies.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class FindMinimumJUnitVersionTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new FindMinimumJUnitVersion(null));
+    }
+
+    @Test
+    void minimumMavenJUnit4() {
+        rewriteRun(
+          mavenProject(
+            "core",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>4.12</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """,
+              """
+                <!--~~(junit:junit:4.12)~~>--><project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>4.12</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void minimumMavenJUnit5() {
+        rewriteRun(
+          mavenProject(
+            "core",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.8.1</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """,
+              """
+                <!--~~(org.junit.jupiter:junit-jupiter-api:5.8.1)~~>--><project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.8.1</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void minimumMavenJUnit4AndJUnit5Present() {
+        rewriteRun(
+          mavenProject(
+            "core",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.8.1</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>4.12</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """,
+              """
+                <!--~~(junit:junit:4.12)~~>--><project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.8.1</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>4.12</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void minimumMavenJUnitNotPresent() {
+        rewriteRun(
+          mavenProject(
+            "server",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>server</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.core</groupId>
+                          <artifactId>jackson-core</artifactId>
+                          <version>2.15.0</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void findIfJUnit4IsMinimumMaven() {
+        rewriteRun(
+          spec -> spec.recipe(new FindMinimumJUnitVersion("4")),
+          mavenProject(
+            "core",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.8.1</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>4.12</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """,
+              """
+                <!--~~(junit:junit:4.12)~~>--><project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.8.1</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>4.12</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void findIfJUnit5IsMinimumMaven() {
+        rewriteRun(
+          spec -> spec.recipe(new FindMinimumJUnitVersion("5")),
+          mavenProject(
+            "core",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.8.1</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """,
+              """
+                <!--~~(org.junit.jupiter:junit-jupiter-api:5.8.1)~~>--><project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.8.1</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void findIfJUnit5IsMinimumMavenButJUnit4IsUsed() {
+        rewriteRun(
+          spec -> spec.recipe(new FindMinimumJUnitVersion("5")),
+          mavenProject(
+            "core",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.8.1</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>4.12</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void findIfJUnit4IsMinimumMavenButJUnit5IsUsed() {
+        rewriteRun(
+          spec -> spec.recipe(new FindMinimumJUnitVersion("4")),
+          mavenProject(
+            "core",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <groupId>org.openrewrite</groupId>
+                  <artifactId>core</artifactId>
+                  <version>0.1.0-SNAPSHOT</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.8.1</version>
+                      </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void minimumGradleJUnit4() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()),
+          mavenProject(
+            "core",
+            //language=groovy
+            buildGradle(
+              """
+                plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    testImplementation 'junit:junit:4.12'
+                }
+                """,
+              """
+                /*~~(junit:junit:4.12)~~>*/plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    testImplementation 'junit:junit:4.12'
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void minimumGradleJUnit5() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()),
+          mavenProject(
+            "core",
+            //language=groovy
+            buildGradle(
+              """
+                plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                }
+                """,
+              """
+                /*~~(org.junit.jupiter:junit-jupiter-api:5.8.1)~~>*/plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void minimumGradleJUnit4AndJUnit5Present() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()),
+          mavenProject(
+            "core",
+            //language=groovy
+            buildGradle(
+              """
+                plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    testImplementation 'junit:junit:4.12'
+                }
+                """,
+              """
+                /*~~(junit:junit:4.12)~~>*/plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    testImplementation 'junit:junit:4.12'
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void minimumGradleJUnitNotPresent() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()),
+          mavenProject(
+            "core",
+            //language=groovy
+            buildGradle(
+              """
+                plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void findIfJUnit4IsMinimumGradle() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()).recipe(new FindMinimumJUnitVersion("4")),
+          mavenProject(
+            "core",
+            //language=groovy
+            buildGradle(
+              """
+                plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    testImplementation 'junit:junit:4.12'
+                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                }
+                """,
+              """
+                /*~~(junit:junit:4.12)~~>*/plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    testImplementation 'junit:junit:4.12'
+                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void findIfJUnit5IsMinimumGradleButJUnit4IsUsed() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()).recipe(new FindMinimumJUnitVersion("5")),
+          mavenProject(
+            "core",
+            //language=groovy
+            buildGradle(
+              """
+                plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                    testImplementation 'junit:junit:4.12'
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void findIfJUnit4IsMinimumGradleButJUnit5IsUsed() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi()).recipe(new FindMinimumJUnitVersion("4")),
+          mavenProject(
+            "core",
+            //language=groovy
+            buildGradle(
+              """
+                plugins { id 'java' }
+                repositories { mavenCentral() }
+                dependencies {
+                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                }
+                """
+            )
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/dependencies/search/FindMinimumJunitVersionTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/FindMinimumJunitVersionTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.dependencies.search;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -31,481 +32,487 @@ class FindMinimumJUnitVersionTest implements RewriteTest {
         spec.recipe(new FindMinimumJUnitVersion(null));
     }
 
-    @Test
-    void minimumMavenJUnit4() {
-        rewriteRun(
-          mavenProject(
-            "core",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>junit</groupId>
-                          <artifactId>junit</artifactId>
-                          <version>4.12</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """,
-              """
-                <!--~~(junit:junit:4.12)~~>--><project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>junit</groupId>
-                          <artifactId>junit</artifactId>
-                          <version>4.12</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """
-            )
-          )
-        );
+    @Nested
+    class Maven {
+        @Test
+        void minimumJUnit4() {
+            rewriteRun(
+              mavenProject(
+                "core",
+                //language=xml
+                pomXml(
+                  """
+                    <project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>junit</groupId>
+                              <artifactId>junit</artifactId>
+                              <version>4.12</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """,
+                  """
+                    <!--~~(junit:junit:4.12)~~>--><project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>junit</groupId>
+                              <artifactId>junit</artifactId>
+                              <version>4.12</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
+
+        @Test
+        void minimumJUnit5() {
+            rewriteRun(
+              mavenProject(
+                "core",
+                //language=xml
+                pomXml(
+                  """
+                    <project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit.jupiter</groupId>
+                              <artifactId>junit-jupiter-api</artifactId>
+                              <version>5.8.1</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """,
+                  """
+                    <!--~~(org.junit.jupiter:junit-jupiter-api:5.8.1)~~>--><project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit.jupiter</groupId>
+                              <artifactId>junit-jupiter-api</artifactId>
+                              <version>5.8.1</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
+
+        @Test
+        void minimumJUnit4AndJUnit5Present() {
+            rewriteRun(
+              mavenProject(
+                "core",
+                //language=xml
+                pomXml(
+                  """
+                    <project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit.jupiter</groupId>
+                              <artifactId>junit-jupiter-api</artifactId>
+                              <version>5.8.1</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>junit</groupId>
+                              <artifactId>junit</artifactId>
+                              <version>4.12</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """,
+                  """
+                    <!--~~(junit:junit:4.12)~~>--><project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit.jupiter</groupId>
+                              <artifactId>junit-jupiter-api</artifactId>
+                              <version>5.8.1</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>junit</groupId>
+                              <artifactId>junit</artifactId>
+                              <version>4.12</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
+
+        @Test
+        void minimumJUnitNotPresent() {
+            rewriteRun(
+              mavenProject(
+                "server",
+                //language=xml
+                pomXml(
+                  """
+                    <project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>server</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>com.fasterxml.jackson.core</groupId>
+                              <artifactId>jackson-core</artifactId>
+                              <version>2.15.0</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
+
+        @Test
+        void findIfJUnit4IsMinimum() {
+            rewriteRun(
+              spec -> spec.recipe(new FindMinimumJUnitVersion("4")),
+              mavenProject(
+                "core",
+                //language=xml
+                pomXml(
+                  """
+                    <project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit.jupiter</groupId>
+                              <artifactId>junit-jupiter-api</artifactId>
+                              <version>5.8.1</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>junit</groupId>
+                              <artifactId>junit</artifactId>
+                              <version>4.12</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """,
+                  """
+                    <!--~~(junit:junit:4.12)~~>--><project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit.jupiter</groupId>
+                              <artifactId>junit-jupiter-api</artifactId>
+                              <version>5.8.1</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>junit</groupId>
+                              <artifactId>junit</artifactId>
+                              <version>4.12</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
+
+        @Test
+        void findIfJUnit5IsMinimum() {
+            rewriteRun(
+              spec -> spec.recipe(new FindMinimumJUnitVersion("5")),
+              mavenProject(
+                "core",
+                //language=xml
+                pomXml(
+                  """
+                    <project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit.jupiter</groupId>
+                              <artifactId>junit-jupiter-api</artifactId>
+                              <version>5.8.1</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """,
+                  """
+                    <!--~~(org.junit.jupiter:junit-jupiter-api:5.8.1)~~>--><project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit.jupiter</groupId>
+                              <artifactId>junit-jupiter-api</artifactId>
+                              <version>5.8.1</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
+
+        @Test
+        void findIfJUnit5IsMinimumButJUnit4IsUsed() {
+            rewriteRun(
+              spec -> spec.recipe(new FindMinimumJUnitVersion("5")),
+              mavenProject(
+                "core",
+                //language=xml
+                pomXml(
+                  """
+                    <project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit.jupiter</groupId>
+                              <artifactId>junit-jupiter-api</artifactId>
+                              <version>5.8.1</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>junit</groupId>
+                              <artifactId>junit</artifactId>
+                              <version>4.12</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
+
+        @Test
+        void findIfJUnit4IsMinimumButJUnit5IsUsed() {
+            rewriteRun(
+              spec -> spec.recipe(new FindMinimumJUnitVersion("4")),
+              mavenProject(
+                "core",
+                //language=xml
+                pomXml(
+                  """
+                    <project>
+                      <groupId>org.openrewrite</groupId>
+                      <artifactId>core</artifactId>
+                      <version>0.1.0-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit.jupiter</groupId>
+                              <artifactId>junit-jupiter-api</artifactId>
+                              <version>5.8.1</version>
+                          </dependency>
+                      </dependencies>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
     }
 
-    @Test
-    void minimumMavenJUnit5() {
-        rewriteRun(
-          mavenProject(
-            "core",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter-api</artifactId>
-                          <version>5.8.1</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """,
-              """
-                <!--~~(org.junit.jupiter:junit-jupiter-api:5.8.1)~~>--><project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter-api</artifactId>
-                          <version>5.8.1</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """
-            )
-          )
-        );
-    }
+    @Nested
+    class Gradle {
+        @Test
+        void minimumJUnit4() {
+            rewriteRun(
+              spec -> spec.beforeRecipe(withToolingApi()),
+              mavenProject(
+                "core",
+                //language=groovy
+                buildGradle(
+                  """
+                    plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        testImplementation 'junit:junit:4.12'
+                    }
+                    """,
+                  """
+                    /*~~(junit:junit:4.12)~~>*/plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        testImplementation 'junit:junit:4.12'
+                    }
+                    """
+                )
+              )
+            );
+        }
 
-    @Test
-    void minimumMavenJUnit4AndJUnit5Present() {
-        rewriteRun(
-          mavenProject(
-            "core",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter-api</artifactId>
-                          <version>5.8.1</version>
-                      </dependency>
-                      <dependency>
-                          <groupId>junit</groupId>
-                          <artifactId>junit</artifactId>
-                          <version>4.12</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """,
-              """
-                <!--~~(junit:junit:4.12)~~>--><project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter-api</artifactId>
-                          <version>5.8.1</version>
-                      </dependency>
-                      <dependency>
-                          <groupId>junit</groupId>
-                          <artifactId>junit</artifactId>
-                          <version>4.12</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """
-            )
-          )
-        );
-    }
+        @Test
+        void minimumJUnit5() {
+            rewriteRun(
+              spec -> spec.beforeRecipe(withToolingApi()),
+              mavenProject(
+                "core",
+                //language=groovy
+                buildGradle(
+                  """
+                    plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                    }
+                    """,
+                  """
+                    /*~~(org.junit.jupiter:junit-jupiter-api:5.8.1)~~>*/plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                    }
+                    """
+                )
+              )
+            );
+        }
 
-    @Test
-    void minimumMavenJUnitNotPresent() {
-        rewriteRun(
-          mavenProject(
-            "server",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>server</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>com.fasterxml.jackson.core</groupId>
-                          <artifactId>jackson-core</artifactId>
-                          <version>2.15.0</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """
-            )
-          )
-        );
-    }
+        @Test
+        void minimumJUnit4AndJUnit5Present() {
+            rewriteRun(
+              spec -> spec.beforeRecipe(withToolingApi()),
+              mavenProject(
+                "core",
+                //language=groovy
+                buildGradle(
+                  """
+                    plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        testImplementation 'junit:junit:4.12'
+                    }
+                    """,
+                  """
+                    /*~~(junit:junit:4.12)~~>*/plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        testImplementation 'junit:junit:4.12'
+                    }
+                    """
+                )
+              )
+            );
+        }
 
-    @Test
-    void findIfJUnit4IsMinimumMaven() {
-        rewriteRun(
-          spec -> spec.recipe(new FindMinimumJUnitVersion("4")),
-          mavenProject(
-            "core",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter-api</artifactId>
-                          <version>5.8.1</version>
-                      </dependency>
-                      <dependency>
-                          <groupId>junit</groupId>
-                          <artifactId>junit</artifactId>
-                          <version>4.12</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """,
-              """
-                <!--~~(junit:junit:4.12)~~>--><project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter-api</artifactId>
-                          <version>5.8.1</version>
-                      </dependency>
-                      <dependency>
-                          <groupId>junit</groupId>
-                          <artifactId>junit</artifactId>
-                          <version>4.12</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """
-            )
-          )
-        );
-    }
+        @Test
+        void minimumJUnitNotPresent() {
+            rewriteRun(
+              spec -> spec.beforeRecipe(withToolingApi()),
+              mavenProject(
+                "core",
+                //language=groovy
+                buildGradle(
+                  """
+                    plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+                    }
+                    """
+                )
+              )
+            );
+        }
 
-    @Test
-    void findIfJUnit5IsMinimumMaven() {
-        rewriteRun(
-          spec -> spec.recipe(new FindMinimumJUnitVersion("5")),
-          mavenProject(
-            "core",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter-api</artifactId>
-                          <version>5.8.1</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """,
-              """
-                <!--~~(org.junit.jupiter:junit-jupiter-api:5.8.1)~~>--><project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter-api</artifactId>
-                          <version>5.8.1</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """
-            )
-          )
-        );
-    }
+        @Test
+        void findIfJUnit4IsMinimum() {
+            rewriteRun(
+              spec -> spec.beforeRecipe(withToolingApi()).recipe(new FindMinimumJUnitVersion("4")),
+              mavenProject(
+                "core",
+                //language=groovy
+                buildGradle(
+                  """
+                    plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        testImplementation 'junit:junit:4.12'
+                        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                    }
+                    """,
+                  """
+                    /*~~(junit:junit:4.12)~~>*/plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        testImplementation 'junit:junit:4.12'
+                        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                    }
+                    """
+                )
+              )
+            );
+        }
 
-    @Test
-    void findIfJUnit5IsMinimumMavenButJUnit4IsUsed() {
-        rewriteRun(
-          spec -> spec.recipe(new FindMinimumJUnitVersion("5")),
-          mavenProject(
-            "core",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter-api</artifactId>
-                          <version>5.8.1</version>
-                      </dependency>
-                      <dependency>
-                          <groupId>junit</groupId>
-                          <artifactId>junit</artifactId>
-                          <version>4.12</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """
-            )
-          )
-        );
-    }
+        @Test
+        void findIfJUnit5IsMinimumButJUnit4IsUsed() {
+            rewriteRun(
+              spec -> spec.beforeRecipe(withToolingApi()).recipe(new FindMinimumJUnitVersion("5")),
+              mavenProject(
+                "core",
+                //language=groovy
+                buildGradle(
+                  """
+                    plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                        testImplementation 'junit:junit:4.12'
+                    }
+                    """
+                )
+              )
+            );
+        }
 
-    @Test
-    void findIfJUnit4IsMinimumMavenButJUnit5IsUsed() {
-        rewriteRun(
-          spec -> spec.recipe(new FindMinimumJUnitVersion("4")),
-          mavenProject(
-            "core",
-            //language=xml
-            pomXml(
-              """
-                <project>
-                  <groupId>org.openrewrite</groupId>
-                  <artifactId>core</artifactId>
-                  <version>0.1.0-SNAPSHOT</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.junit.jupiter</groupId>
-                          <artifactId>junit-jupiter-api</artifactId>
-                          <version>5.8.1</version>
-                      </dependency>
-                  </dependencies>
-                </project>
-                """
-            )
-          )
-        );
-    }
-
-    @Test
-    void minimumGradleJUnit4() {
-        rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()),
-          mavenProject(
-            "core",
-            //language=groovy
-            buildGradle(
-              """
-                plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    testImplementation 'junit:junit:4.12'
-                }
-                """,
-              """
-                /*~~(junit:junit:4.12)~~>*/plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    testImplementation 'junit:junit:4.12'
-                }
-                """
-            )
-          )
-        );
-    }
-
-    @Test
-    void minimumGradleJUnit5() {
-        rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()),
-          mavenProject(
-            "core",
-            //language=groovy
-            buildGradle(
-              """
-                plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-                }
-                """,
-              """
-                /*~~(org.junit.jupiter:junit-jupiter-api:5.8.1)~~>*/plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-                }
-                """
-            )
-          )
-        );
-    }
-
-    @Test
-    void minimumGradleJUnit4AndJUnit5Present() {
-        rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()),
-          mavenProject(
-            "core",
-            //language=groovy
-            buildGradle(
-              """
-                plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    testImplementation 'junit:junit:4.12'
-                }
-                """,
-              """
-                /*~~(junit:junit:4.12)~~>*/plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    testImplementation 'junit:junit:4.12'
-                }
-                """
-            )
-          )
-        );
-    }
-
-    @Test
-    void minimumGradleJUnitNotPresent() {
-        rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()),
-          mavenProject(
-            "core",
-            //language=groovy
-            buildGradle(
-              """
-                plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
-                }
-                """
-            )
-          )
-        );
-    }
-
-    @Test
-    void findIfJUnit4IsMinimumGradle() {
-        rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()).recipe(new FindMinimumJUnitVersion("4")),
-          mavenProject(
-            "core",
-            //language=groovy
-            buildGradle(
-              """
-                plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    testImplementation 'junit:junit:4.12'
-                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-                }
-                """,
-              """
-                /*~~(junit:junit:4.12)~~>*/plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    testImplementation 'junit:junit:4.12'
-                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-                }
-                """
-            )
-          )
-        );
-    }
-
-    @Test
-    void findIfJUnit5IsMinimumGradleButJUnit4IsUsed() {
-        rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()).recipe(new FindMinimumJUnitVersion("5")),
-          mavenProject(
-            "core",
-            //language=groovy
-            buildGradle(
-              """
-                plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-                    testImplementation 'junit:junit:4.12'
-                }
-                """
-            )
-          )
-        );
-    }
-
-    @Test
-    void findIfJUnit4IsMinimumGradleButJUnit5IsUsed() {
-        rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi()).recipe(new FindMinimumJUnitVersion("4")),
-          mavenProject(
-            "core",
-            //language=groovy
-            buildGradle(
-              """
-                plugins { id 'java' }
-                repositories { mavenCentral() }
-                dependencies {
-                    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-                }
-                """
-            )
-          )
-        );
+        @Test
+        void findIfJUnit4IsMinimumButJUnit5IsUsed() {
+            rewriteRun(
+              spec -> spec.beforeRecipe(withToolingApi()).recipe(new FindMinimumJUnitVersion("4")),
+              mavenProject(
+                "core",
+                //language=groovy
+                buildGradle(
+                  """
+                    plugins { id 'java' }
+                    repositories { mavenCentral() }
+                    dependencies {
+                        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+                    }
+                    """
+                )
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
## What's changed?
Adding a new recipe which returns the minimum JUnit version 

## What's your motivation?
We need a recipe to return the minimum JUnit version for the DevCenter. Currently, we are finding annotations but this finds all JUnits versions which are used not the minimum version which is used
- https://github.com/moderneinc/moderne-devcenter/issues/602


