### PR TITLE
Transform the UpgradeTransitiveDependencyVersion to be a ScanningRecipe

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java
@@ -19,12 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
-import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.maven.AddManagedDependency;
-import org.openrewrite.maven.tree.GroupArtifact;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 @Value
 @EqualsAndHashCode(callSuper = false)


### PR DESCRIPTION
## What's changed?
After we made UpgradeTransitiveDependencyVersion a ScanningRecipe this one should use the accumulator passed along

SHOULD GO AFTER:
- https://github.com/openrewrite/rewrite/pull/5453

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
