### PR TITLE
Adding `DoesNotIncludeDependency` that will call both the Maven and Gradle versions

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/search/DoesNotIncludeDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/DoesNotIncludeDependency.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.dependencies.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class DoesNotIncludeDependency extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Does not include dependency for Gradle and Maven";
+    }
+
+    @Override
+    public String getDescription() {
+        return "A precondition which returns false if visiting a Gradle file / Maven pom which includes the specified dependency in the classpath of some Gradle configuration / Maven scope. " +
+                "For compatibility with multimodule projects, this should most often be applied as a precondition.";
+    }
+
+    @Option(displayName = "Group",
+            description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. Supports glob.",
+            example = "com.google.guava")
+    String groupId;
+
+    @Option(displayName = "Artifact",
+            description = "The second part of a dependency coordinate `com.google.guava:guava:VERSION`. Supports glob.",
+            example = "guava")
+    String artifactId;
+
+    @Option(displayName = "Only direct dependencies",
+            description = "Default false. If enabled, transitive dependencies will not be considered.",
+            required = false,
+            example = "true")
+    @Nullable
+    Boolean onlyDirect;
+
+    @Option(displayName = "Maven scope",
+            description = "Default any. If specified, only the requested scope's classpaths will be checked.",
+            required = false,
+            valid = {"compile", "test", "runtime", "provided"},
+            example = "compile")
+    @Nullable
+    String scope;
+
+    @Option(displayName = "Gradle configuration",
+            description = "Match dependencies with the specified configuration. If not specified, all configurations will be searched.",
+            example = "compileClasspath",
+            required = false)
+    @Nullable
+    String configuration;
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            final TreeVisitor<?, ExecutionContext> gdnid = new org.openrewrite.gradle.search.DoesNotIncludeDependency(groupId, artifactId, configuration)
+                    .getVisitor();
+            final TreeVisitor<?, ExecutionContext> mdnid = new org.openrewrite.maven.search.DoesNotIncludeDependency(groupId, artifactId, onlyDirect, scope)
+                    .getVisitor();
+
+            @Override
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                return gdnid.isAcceptable(sourceFile, ctx) || mdnid.isAcceptable(sourceFile, ctx);
+            }
+
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (!(tree instanceof SourceFile)) {
+                    return tree;
+                }
+                SourceFile s = (SourceFile) tree;
+                if (gdnid.isAcceptable(s, ctx)) {
+                    s = (SourceFile) gdnid.visitNonNull(s, ctx);
+                } else if (mdnid.isAcceptable(s, ctx)) {
+                    s = (SourceFile) mdnid.visitNonNull(s, ctx);
+                }
+                return s;
+            }
+        };
+    }
+}

--- a/src/test/java/org/openrewrite/java/dependencies/search/DoesNotIncludeDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/DoesNotIncludeDependencyTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.dependencies.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class DoesNotIncludeDependencyTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .beforeRecipe(withToolingApi())
+          .recipe(new DoesNotIncludeDependency("org.springframework", "spring-beans", false, "compile", "compileClasspath"));
+    }
+
+    @DocumentExample
+    @Test
+    void whenDoesNotIncludeDependencyInCorrectScopeOrConfigurationMarks() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <groupId>com.example</groupId>
+                <artifactId>foo</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-beans</artifactId>
+                    <version>6.0.0</version>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <!--~~>--><project>
+                <groupId>com.example</groupId>
+                <artifactId>foo</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-beans</artifactId>
+                    <version>6.0.0</version>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          ),
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <groupId>com.example</groupId>
+                <artifactId>foo</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-beans</artifactId>
+                    <version>6.0.0</version>
+                    <scope>compile</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          ),
+          //language=groovy
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              repositories {
+                mavenCentral()
+              }
+              dependencies {
+                testImplementation 'org.springframework:spring-beans:6.0.0'
+              }
+              """,
+            """
+              /*~~>*/plugins {
+                id 'java-library'
+              }
+              repositories {
+                mavenCentral()
+              }
+              dependencies {
+                testImplementation 'org.springframework:spring-beans:6.0.0'
+              }
+              """
+          ),
+          //language=groovy
+          buildGradle(
+            """
+              plugins {
+                id 'java-library'
+              }
+              repositories {
+                mavenCentral()
+              }
+              dependencies {
+                implementation 'org.springframework:spring-beans:6.0.0'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenInapplicableFileTypeDoesNotMark() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class SomeClass {}
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/dependencies/search/DoesNotIncludeDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/DoesNotIncludeDependencyTest.java
@@ -70,24 +70,6 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               </project>
               """
           ),
-          //language=xml
-          pomXml(
-            """
-              <project>
-                <groupId>com.example</groupId>
-                <artifactId>foo</artifactId>
-                <version>1.0.0</version>
-                <dependencies>
-                  <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-beans</artifactId>
-                    <version>6.0.0</version>
-                    <scope>compile</scope>
-                  </dependency>
-                </dependencies>
-              </project>
-              """
-          ),
           //language=groovy
           buildGradle(
             """
@@ -111,6 +93,30 @@ class DoesNotIncludeDependencyTest implements RewriteTest {
               dependencies {
                 testImplementation 'org.springframework:spring-beans:6.0.0'
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenIncludesDependencyInCorrectScopeOrConfigurationDoesNotMark() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <groupId>com.example</groupId>
+                <artifactId>foo</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-beans</artifactId>
+                    <version>6.0.0</version>
+                    <scope>compile</scope>
+                  </dependency>
+                </dependencies>
+              </project>
               """
           ),
           //language=groovy


### PR DESCRIPTION
## What's changed?
`DoesNotIncludeDependency` added that will call the Gradle and Maven versions as applicable.

## What's your motivation?
This would be used as opposed to calling each the Maven and Gradle versions sequentially

## Note
- Current draft until https://github.com/openrewrite/rewrite/pull/5758 gets merged, as the behaviours associated with not marking inapplicable files are part of that. Will rerun the CI once that is in.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
