### PR TITLE
Adding `invertMarking` flag to `ModuleHasDependency` for flipping what gets marked

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/search/ModuleHasDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/ModuleHasDependency.java
@@ -120,7 +120,8 @@ public class ModuleHasDependency extends ScanningRecipe<Set<JavaProject>> {
                 String dependencyGav = groupIdPattern + ":" + artifactIdPattern + (version == null ? "" : ":" + version);
                 if (shouldInvert && !acc.contains(jp)) {
                     return SearchResult.found(tree, "Module does not have dependency: " + dependencyGav);
-                } else if (!shouldInvert && acc.contains(jp)) {
+                }
+                if (!shouldInvert && acc.contains(jp)) {
                     return SearchResult.found(tree, "Module has dependency: " + dependencyGav);
                 }
                 return tree;

--- a/src/test/java/org/openrewrite/java/dependencies/search/ModuleHasDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/ModuleHasDependencyTest.java
@@ -46,8 +46,8 @@ class ModuleHasDependencyTest implements RewriteTest {
         spec.beforeRecipe(withToolingApi());
     }
 
-    @ParameterizedTest
     @NullSource
+    @ParameterizedTest
     @ValueSource(booleans = {false})
     void whenModuleHasDirectDependencyMarks(Boolean invertCondition) {
         final String groupId = "org.springframework";
@@ -178,8 +178,8 @@ class ModuleHasDependencyTest implements RewriteTest {
         );
     }
 
-    @ParameterizedTest
     @NullSource
+    @ParameterizedTest
     @ValueSource(booleans = {false})
     void whenModuleHasTransitiveDependencyMarks(Boolean invertCondition) {
         final String groupId = "org.springframework";
@@ -310,8 +310,8 @@ class ModuleHasDependencyTest implements RewriteTest {
         );
     }
 
-    @ParameterizedTest
     @NullSource
+    @ParameterizedTest
     @ValueSource(booleans = {false})
     void whenModuleDoesNotHaveDependencyDoesNotMark(Boolean invertCondition) {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
`invertMarking` optional boolean flag added to `ModuleHasDependency` that flips what files get marked during the visitor (and changes the message from `Module has dependency: ...` to `Module does not have dependency: ...` when flipping.

## What's your motivation?
To allow it to switch between marking files part of a module with a dependency (default / original behaviour / when flag is set to false or not provided) and marking files part of a module that doesn't have a dependency (when the flag is set to true)

- Spawned from comment here: https://github.com/openrewrite/rewrite-testing-frameworks/pull/760#discussion_r2243593939

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
