### PR TITLE
Update license header in FindDependency.java

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/FindDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/FindDependency.java
@@ -1,7 +1,17 @@
 /*
  * Copyright 2025 the original author or authors.
- *
- * Moderne Proprietary. Only for use by Moderne customers under the terms of a commercial contract.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.openrewrite.java.dependencies;
 


### PR DESCRIPTION
Updated license information in FindDependency.java to match rest of rewrite-java-dependencies

--- 

I figured this was easier to propose than opening an issue and then a PR.

The rest of the repository and all other class headers are Apache 2.0, but this recipe was added last month with the proprietary license header. I think this header was possibly included incorrectly, because I don't think "Only for use by Moderne customers under the terms of a commercial contract." can be enforced when the library is labeled as Apache 2.0.

Feel free to close this propose change if needed.

## What's changed?
<!-- A brief description of the changes in this pull request -->
License header in FindDependency to match rest of repo.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
I guess I'd like to use FindDependency, legally.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

@sambsnyd 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
n/a

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
n/a

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
