### PR TITLE
Pass "because" value to Maven recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java
@@ -165,6 +165,6 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
     }
 
     private org.openrewrite.maven.UpgradeTransitiveDependencyVersion getMavenUpgradeTransitive() {
-        return new org.openrewrite.maven.UpgradeTransitiveDependencyVersion(groupId, artifactId, version, scope, type, classifier, versionPattern, releasesOnly, onlyIfUsing, addToRootPom);
+        return new org.openrewrite.maven.UpgradeTransitiveDependencyVersion(groupId, artifactId, version, scope, type, classifier, versionPattern, releasesOnly, onlyIfUsing, addToRootPom, because);
     }
 }


### PR DESCRIPTION
## What's changed?

The "because" option value needs to be consumed by Maven recipe.

## What's your motivation?

- Follow up to https://github.com/openrewrite/rewrite/pull/6160.

## Anything in particular you'd like reviewers to focus on?

No
