### PR TITLE
Remove redundant dependencies

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/RemoveRedundantDependencies.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveRedundantDependencies.java
@@ -164,20 +164,11 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
             }
 
             private ResolvedPom applyExclusions(ResolvedPom resolvedPom, List<GroupArtifact> effectiveExclusions) {
-                List<Dependency> existingRequested_dependencies = resolvedPom.getRequested().getDependencies();
-                ResolvedPom patchedPom = resolvedPom
-                        .withRequested(
-                                resolvedPom.getRequested().withDependencies(
-                                        ListUtils.filter(
-                                                existingRequested_dependencies,
-                                                d -> effectiveExclusions.stream()
-                                                        .noneMatch(e -> e.getGroupId().equals(d.getGroupId()) && e.getArtifactId().equals(d.getArtifactId()))
-                                        )
-                                )
-                        );
-                patchedPom.getRequestedDependencies()
-                        .removeIf(d -> effectiveExclusions.stream()
-                                .anyMatch(e -> e.getGroupId().equals(d.getGroupId()) && e.getArtifactId().equals(d.getArtifactId())));
+                ResolvedPom patchedPom = resolvedPom.withRequested(resolvedPom.getRequested().withDependencies(
+                        ListUtils.filter(resolvedPom.getRequested().getDependencies(), d -> effectiveExclusions.stream()
+                                .noneMatch(e -> e.getGroupId().equals(d.getGroupId()) && e.getArtifactId().equals(d.getArtifactId())))));
+                patchedPom.getRequestedDependencies().removeIf(d -> effectiveExclusions.stream()
+                        .anyMatch(e -> e.getGroupId().equals(d.getGroupId()) && e.getArtifactId().equals(d.getArtifactId())));
                 return patchedPom;
             }
 

--- a/src/test/java/org/openrewrite/java/dependencies/RemoveRedundantDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RemoveRedundantDependenciesTest.java
@@ -25,24 +25,21 @@ import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class RemoveRedundantDependenciesTest implements RewriteTest {
-
     @DocumentExample
     @Test
     void removeRedundantMavenDependency() {
         rewriteRun(
           spec -> spec.recipe(new RemoveRedundantDependencies(
-                  "com.fasterxml.jackson.core", "jackson-databind")),
+            "com.fasterxml.jackson.core", "jackson-databind")),
           mavenProject("my-app",
             //language=xml
             pomXml(
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>com.fasterxml.jackson.core</groupId>
@@ -60,11 +57,9 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>com.fasterxml.jackson.core</groupId>
@@ -90,11 +85,9 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>org.junit.jupiter</groupId>
@@ -114,11 +107,9 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>org.junit.jupiter</groupId>
@@ -138,18 +129,16 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
     void removeMultipleRedundantDependencies() {
         rewriteRun(
           spec -> spec.recipe(new RemoveRedundantDependencies(
-                  "com.fasterxml.jackson.core", "jackson-databind")),
+            "com.fasterxml.jackson.core", "jackson-databind")),
           mavenProject("my-app",
             //language=xml
             pomXml(
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>com.fasterxml.jackson.core</groupId>
@@ -172,11 +161,9 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>com.fasterxml.jackson.core</groupId>
@@ -195,18 +182,16 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
     void doNotRemoveWhenVersionsDiffer() {
         rewriteRun(
           spec -> spec.recipe(new RemoveRedundantDependencies(
-                  "com.fasterxml.jackson.core", "jackson-databind")),
+            "com.fasterxml.jackson.core", "jackson-databind")),
           mavenProject("my-app",
             //language=xml
             pomXml(
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>com.fasterxml.jackson.core</groupId>
@@ -237,11 +222,9 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>com.fasterxml.jackson.core</groupId>
@@ -271,18 +254,16 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
     void doNotRemoveDirectDependencyItself() {
         rewriteRun(
           spec -> spec.recipe(new RemoveRedundantDependencies(
-                  "com.fasterxml.jackson.core", "jackson-databind")),
+            "com.fasterxml.jackson.core", "jackson-databind")),
           mavenProject("my-app",
             //language=xml
             pomXml(
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>com.fasterxml.jackson.core</groupId>
@@ -301,18 +282,16 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
     void noMatchingParentDependency() {
         rewriteRun(
           spec -> spec.recipe(new RemoveRedundantDependencies(
-                  "org.nonexistent", "nonexistent")),
+            "org.nonexistent", "nonexistent")),
           mavenProject("my-app",
             //language=xml
             pomXml(
               """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
-
                   <groupId>com.mycompany.app</groupId>
                   <artifactId>my-app</artifactId>
                   <version>1</version>
-
                   <dependencies>
                     <dependency>
                       <groupId>com.fasterxml.jackson.core</groupId>
@@ -337,7 +316,7 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
         rewriteRun(
           spec -> spec.beforeRecipe(withToolingApi())
             .recipe(new RemoveRedundantDependencies(
-                    "com.fasterxml.jackson.core", "jackson-databind")),
+              "com.fasterxml.jackson.core", "jackson-databind")),
           mavenProject("my-app",
             //language=groovy
             buildGradle(
@@ -345,11 +324,9 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
                 plugins {
                     id 'java-library'
                 }
-
                 repositories {
                     mavenCentral()
                 }
-
                 dependencies {
                     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
                     implementation 'com.fasterxml.jackson.core:jackson-core:2.17.0'
@@ -359,11 +336,9 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
                 plugins {
                     id 'java-library'
                 }
-
                 repositories {
                     mavenCentral()
                 }
-
                 dependencies {
                     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
                 }


### PR DESCRIPTION
Remove direct dependencies that are also brought in transitively by other direct dependencies.

Intended to be used when introducing spring boot starters to remove the direct dependencies they bring in.