### PR TITLE
Updating `AddDependency` test to better reflect allowed scopes for Maven

### DIFF
--- a/src/test/java/org/openrewrite/java/dependencies/AddDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/AddDependencyTest.java
@@ -49,12 +49,12 @@ class AddDependencyTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    void addMavenDependencyWithSystemScope() {
+    void addMavenDependencyWithOnlyIfUsingTestScope() {
         rewriteRun(
           spec -> spec
-            .recipe(addDependency("doesnotexist:doesnotexist:1", "com.google.common.math.IntMath", "system")),
+            .recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath", "test")),
           mavenProject("project",
-            srcMainJava(
+            srcTestJava(
               java(usingGuavaIntMath)
             ),
             //language=xml
@@ -73,10 +73,10 @@ class AddDependencyTest implements RewriteTest {
                     <version>1</version>
                     <dependencies>
                         <dependency>
-                            <groupId>doesnotexist</groupId>
-                            <artifactId>doesnotexist</artifactId>
-                            <version>1</version>
-                            <scope>system</scope>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>29.0-jre</version>
+                            <scope>test</scope>
                         </dependency>
                     </dependencies>
                 </project>


### PR DESCRIPTION
## What's changed?
Scope used in test changed to `test` rather than `system`, which isn't allowed for the recipe logic-wise anymore, and wasn't in the allowed list of scopes for the recipe declaratively to begin with.

## What's your motivation?
- https://github.com/openrewrite/rewrite/pull/6434

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
