### PR TITLE
Pin empty MavenSettings in DependencyResolutionDiagnosticTest.maven()

### DIFF
--- a/src/test/java/org/openrewrite/java/dependencies/DependencyResolutionDiagnosticTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/DependencyResolutionDiagnosticTest.java
@@ -183,15 +183,31 @@ class DependencyResolutionDiagnosticTest implements RewriteTest {
     @Test
     void maven() {
         rewriteRun(
-          spec -> spec.beforeRecipe(withToolingApi())
-            .dataTable(RepositoryAccessibilityReport.Row.class, rows -> {
-                assertThat(rows).contains(
-                  new RepositoryAccessibilityReport.Row("https://repo.maven.apache.org/maven2", "", "", 200, "", ""));
-                assertThat(rows).filteredOn(row -> row.getUri().startsWith("file:/") && "".equals(row.getPingExceptionMessage())).hasSize(1);
-                assertThat(rows).contains(
-                  new RepositoryAccessibilityReport.Row("https://nonexistent.moderne.io/maven2", "java.net.UnknownHostException", "nonexistent.moderne.io", null, "", "")
-                );
-            }),
+          spec -> {
+              // CI may inject ~/.m2/settings.xml with `<mirrorOf>*</mirrorOf>` to route Maven through a cache.
+              // That rewrites the pom-declared `nonexistent` repo to the mirror URL, so neither Maven Central
+              // nor the test's `nonexistent.moderne.io` repo appear in the diagnostic. Force empty settings
+              // here so the recipe sees the pom-declared repositories directly.
+              MavenExecutionContextView ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
+              MavenSettings emptySettings = MavenSettings.parse(new Parser.Input(Path.of("settings.xml"), () -> new ByteArrayInputStream(
+                //language=xml
+                """
+                  <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd"/>
+                  """.getBytes())), ctx);
+              ctx.setMavenSettings(emptySettings);
+              spec.beforeRecipe(withToolingApi())
+                .dataTable(RepositoryAccessibilityReport.Row.class, rows -> {
+                    assertThat(rows).contains(
+                      new RepositoryAccessibilityReport.Row("https://repo.maven.apache.org/maven2", "", "", 200, "", ""));
+                    assertThat(rows).filteredOn(row -> row.getUri().startsWith("file:/") && "".equals(row.getPingExceptionMessage())).hasSize(1);
+                    assertThat(rows).contains(
+                      new RepositoryAccessibilityReport.Row("https://nonexistent.moderne.io/maven2", "java.net.UnknownHostException", "nonexistent.moderne.io", null, "", "")
+                    );
+                })
+                .executionContext(ctx);
+          },
           //language=xml
           pomXml(
             """


### PR DESCRIPTION
## Summary
`openrewrite/gh-automation#95` installs `~/.m2/settings.xml` with `<mirrorOf>*</mirrorOf>` to route Maven through `artifactory.moderne.ninja` (avoiding HTTP 429 from Maven Central). The mirror rewrites every repository request — including the test pom's deliberately-unreachable `<repository><url>https://nonexistent.moderne.io/maven2</url></repository>` — so the diagnostic recipe only sees the mirror and the local file cache. Neither Maven Central nor the test repo appear in the data table; both `contains(...)` assertions fail.

Inject an explicit empty `MavenSettings` via `MavenExecutionContextView` (same pattern as the existing `mavenSettingsWithMirrors` test) so the recipe ignores `~/.m2/settings.xml` and sees the pom-declared repositories directly. The original three assertions are restored unchanged.

Failing CI run: https://github.com/openrewrite/rewrite-java-dependencies/actions/runs/26053770256

## Test plan
- [x] `./gradlew test --tests "org.openrewrite.java.dependencies.DependencyResolutionDiagnosticTest"` passes locally
- [ ] CI passes in this PR (with mirror)