### PR TITLE
Match requested dependencies in ModuleHasDependency and RepositoryHasDependency

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/search/ModuleHasDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/ModuleHasDependency.java
@@ -21,8 +21,10 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.maven.tree.Dependency;
 import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.maven.tree.ResolvedDependency;
 import org.openrewrite.maven.tree.Scope;
@@ -115,6 +117,11 @@ public class ModuleHasDependency extends ScanningRecipe<Set<JavaProject>> {
                     return true;
                 }
             }
+            for (Dependency requested : mavenResult.getPom().getRequestedDependencies()) {
+                if (matchesRequested(requested, requestedScope, versionComparator)) {
+                    return true;
+                }
+            }
             return false;
         }
 
@@ -128,8 +135,44 @@ public class ModuleHasDependency extends ScanningRecipe<Set<JavaProject>> {
                     }
                 }
             }
+            for (GradleDependencyConfiguration c : gp.getConfigurations()) {
+                for (Dependency requested : c.getRequested()) {
+                    if (matchesRequested(requested, null, versionComparator)) {
+                        return true;
+                    }
+                }
+            }
         }
         return false;
+    }
+
+    private boolean matchesRequested(Dependency dep, @Nullable Scope requestedScope, @Nullable VersionComparator versionComparator) {
+        if (dep.getGroupId() == null || dep.getArtifactId() == null) {
+            return false;
+        }
+        if (!StringUtils.matchesGlob(dep.getGroupId(), groupIdPattern)) {
+            return false;
+        }
+        if (!StringUtils.matchesGlob(dep.getArtifactId(), artifactIdPattern)) {
+            return false;
+        }
+        if (requestedScope != null) {
+            Scope depScope = dep.getScope() == null ? Scope.Compile : Scope.fromName(dep.getScope());
+            if (!depScope.isInClasspathOf(requestedScope)) {
+                return false;
+            }
+        }
+        return versionMatches(dep.getVersion(), versionComparator);
+    }
+
+    private static boolean versionMatches(@Nullable String version, @Nullable VersionComparator cmp) {
+        if (cmp == null || version == null) {
+            return true;
+        }
+        if (version.startsWith("${")) {
+            return false;
+        }
+        return cmp.isValid(null, version);
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/dependencies/search/RepositoryHasDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/RepositoryHasDependency.java
@@ -21,8 +21,10 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.maven.tree.Dependency;
 import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.maven.tree.ResolvedDependency;
 import org.openrewrite.maven.tree.Scope;
@@ -110,6 +112,11 @@ public class RepositoryHasDependency extends ScanningRecipe<AtomicBoolean> {
                     return true;
                 }
             }
+            for (Dependency requested : mavenResult.getPom().getRequestedDependencies()) {
+                if (matchesRequested(requested, requestedScope, versionComparator)) {
+                    return true;
+                }
+            }
             return false;
         }
 
@@ -123,8 +130,44 @@ public class RepositoryHasDependency extends ScanningRecipe<AtomicBoolean> {
                     }
                 }
             }
+            for (GradleDependencyConfiguration c : gp.getConfigurations()) {
+                for (Dependency requested : c.getRequested()) {
+                    if (matchesRequested(requested, null, versionComparator)) {
+                        return true;
+                    }
+                }
+            }
         }
         return false;
+    }
+
+    private boolean matchesRequested(Dependency dep, @Nullable Scope requestedScope, @Nullable VersionComparator versionComparator) {
+        if (dep.getGroupId() == null || dep.getArtifactId() == null) {
+            return false;
+        }
+        if (!StringUtils.matchesGlob(dep.getGroupId(), groupIdPattern)) {
+            return false;
+        }
+        if (!StringUtils.matchesGlob(dep.getArtifactId(), artifactIdPattern)) {
+            return false;
+        }
+        if (requestedScope != null) {
+            Scope depScope = dep.getScope() == null ? Scope.Compile : Scope.fromName(dep.getScope());
+            if (!depScope.isInClasspathOf(requestedScope)) {
+                return false;
+            }
+        }
+        return versionMatches(dep.getVersion(), versionComparator);
+    }
+
+    private static boolean versionMatches(@Nullable String version, @Nullable VersionComparator cmp) {
+        if (cmp == null || version == null) {
+            return true;
+        }
+        if (version.startsWith("${")) {
+            return false;
+        }
+        return cmp.isValid(null, version);
     }
 
     @Override

--- a/src/test/java/org/openrewrite/java/dependencies/search/ModuleHasDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/ModuleHasDependencyTest.java
@@ -21,8 +21,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.maven.MavenExecutionContextView;
+import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
@@ -344,6 +351,109 @@ class ModuleHasDependencyTest implements RewriteTest {
             )
           )
         );
+    }
+
+    @Nested
+    class WhenDependencyIsRequestedButNotResolved {
+
+        @Language("groovy")
+        private final static String GradleNoRepositories = """
+          plugins {
+            id 'java-library'
+          }
+          dependencies {
+            implementation 'org.springframework:spring-beans:6.0.0'
+          }
+          """;
+
+        @Language("xml")
+        private final static String MavenNoRepositories = """
+          <project>
+            <groupId>com.example</groupId>
+            <artifactId>foo</artifactId>
+            <version>1.0.0</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>6.0.0</version>
+              </dependency>
+            </dependencies>
+          </project>
+          """;
+
+        @Test
+        void gradleMatchesOnRequested() {
+            rewriteRun(
+              spec -> spec.recipe(new ModuleHasDependency(GroupId, ArtifactId, null, null, null)),
+              mavenProject("project-gradle",
+                buildGradle(
+                  GradleNoRepositories,
+                  spec -> spec.after(actual ->
+                    assertThat(actual)
+                      .startsWith(GradleMarkerPositive)
+                      .actual()
+                  )
+                ),
+                java(
+                  GradleJava,
+                  spec -> spec.after(actual ->
+                    assertThat(actual)
+                      .startsWith(JavaMarkerPositive)
+                      .actual()
+                  )
+                )
+              )
+            );
+        }
+
+        @Test
+        void mavenMatchesOnRequested() {
+            rewriteRun(
+              spec -> {
+                  MavenExecutionContextView ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
+                  MavenSettings emptySettings = MavenSettings.parse(new Parser.Input(Path.of("settings.xml"), () -> new ByteArrayInputStream(
+                    //language=xml
+                    """
+                      <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd"/>
+                      """.getBytes())), ctx);
+                  ctx.setMavenSettings(emptySettings);
+                  spec.recipe(new ModuleHasDependency(GroupId, ArtifactId, null, null, null))
+                    .executionContext(ctx);
+              },
+              mavenProject("project-maven",
+                pomXml(
+                  MavenNoRepositories,
+                  spec -> spec.after(actual ->
+                    assertThat(actual)
+                      .startsWith(MavenMarkerPositive)
+                      .actual()
+                  )
+                ),
+                java(
+                  MavenJava,
+                  spec -> spec.after(actual ->
+                    assertThat(actual)
+                      .startsWith(JavaMarkerPositive)
+                      .actual()
+                  )
+                )
+              )
+            );
+        }
+
+        @Test
+        void gradleVersionRangeOnRequestedDoesNotMatchWhenOutOfRange() {
+            rewriteRun(
+              spec -> spec.recipe(new ModuleHasDependency(GroupId, ArtifactId, null, "[7.0,)", null)),
+              mavenProject("project-gradle",
+                buildGradle(GradleNoRepositories),
+                java(GradleJava)
+              )
+            );
+        }
     }
 
 @Nested


### PR DESCRIPTION
## Summary

- After #176 removed `DependencyInsight`, `ModuleHasDependency` and `RepositoryHasDependency` only inspect **resolved** dependencies. A dependency that is declared but never resolved (unit tests without a `repositories` block, partially resolved POMs) is now invisible to these recipes.
- This PR adds a fallback that also matches against **requested** (declared) dependencies for both recipes, on both the Maven and Gradle paths. The fallback runs only after the resolved-deps pass fails, so behavior is unchanged when resolution succeeds.
- This mirrors the existing behavior of `FindDependency` for both Maven (walks the pom XML tags) and Gradle (uses `GradleDependency.Matcher` against the build script AST) — both already match declared dependencies, not the resolved tree. Bringing `ModuleHasDependency` / `RepositoryHasDependency` in line keeps the "find" family of recipes consistent and unblocks a 1-on-1 refactor that swaps one for the other in cleaner recipes.

Version glob handling on the requested-deps path:
- requested version is `null` → accept (no constraint declared).
- requested version starts with `${` → skip (placeholder; cannot evaluate).
- otherwise → compare against the configured version pattern.

Scope filtering is applied to Maven requested deps (default `compile` when null); Gradle does not currently apply scope filtering on the resolved path either, so the requested path mirrors that.

## Test plan

- [x] `gradleMatchesOnRequested` — Gradle build with no `repositories` block; declared `spring-beans` matched via requested fallback.
- [x] `mavenMatchesOnRequested` — pom with no `<repositories>`, pinned empty `MavenSettings` (same trick as #178) so resolution actually fails; declared `spring-beans` matched via requested fallback.
- [x] `gradleVersionRangeOnRequestedDoesNotMatchWhenOutOfRange` — version glob is still enforced on the requested-deps path.
- [x] Full `ModuleHasDependencyTest` + `RepositoryHasDependencyTest` suites still pass.