### PR TITLE
Trust resolved version over declared dep in dependency search

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/search/ModuleHasDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/ModuleHasDependency.java
@@ -112,12 +112,17 @@ public class ModuleHasDependency extends ScanningRecipe<Set<JavaProject>> {
         if (mavenResult != null) {
             Scope requestedScope = scope == null ? null : Scope.fromName(scope);
             List<ResolvedDependency> dependencies = mavenResult.findDependencies(groupIdPattern, artifactIdPattern, requestedScope);
+            Set<String> resolvedGAs = new HashSet<>();
             for (ResolvedDependency dependency : dependencies) {
+                resolvedGAs.add(dependency.getGroupId() + ":" + dependency.getArtifactId());
                 if (versionComparator == null || versionComparator.isValid(null, dependency.getVersion())) {
                     return true;
                 }
             }
             for (Dependency requested : mavenResult.getPom().getRequestedDependencies()) {
+                if (resolvedGAs.contains(requested.getGroupId() + ":" + requested.getArtifactId())) {
+                    continue;
+                }
                 if (matchesRequested(requested, requestedScope, versionComparator)) {
                     return true;
                 }
@@ -127,16 +132,23 @@ public class ModuleHasDependency extends ScanningRecipe<Set<JavaProject>> {
 
         GradleProject gp = tree.getMarkers().findFirst(GradleProject.class).orElse(null);
         if (gp != null) {
+            Set<String> resolvedGAs = new HashSet<>();
             for (GradleDependencyConfiguration c : gp.getConfigurations()) {
                 for (ResolvedDependency resolvedDependency : c.getDirectResolved()) {
                     ResolvedDependency found = resolvedDependency.findDependency(groupIdPattern, artifactIdPattern);
-                    if (found != null && (versionComparator == null || versionComparator.isValid(null, found.getVersion()))) {
-                        return true;
+                    if (found != null) {
+                        resolvedGAs.add(found.getGroupId() + ":" + found.getArtifactId());
+                        if (versionComparator == null || versionComparator.isValid(null, found.getVersion())) {
+                            return true;
+                        }
                     }
                 }
             }
             for (GradleDependencyConfiguration c : gp.getConfigurations()) {
                 for (Dependency requested : c.getRequested()) {
+                    if (resolvedGAs.contains(requested.getGroupId() + ":" + requested.getArtifactId())) {
+                        continue;
+                    }
                     if (matchesRequested(requested, null, versionComparator)) {
                         return true;
                     }
@@ -166,10 +178,10 @@ public class ModuleHasDependency extends ScanningRecipe<Set<JavaProject>> {
     }
 
     private static boolean versionMatches(@Nullable String version, @Nullable VersionComparator cmp) {
-        if (cmp == null || version == null) {
+        if (cmp == null) {
             return true;
         }
-        if (version.startsWith("${")) {
+        if (version == null || version.startsWith("${")) {
             return false;
         }
         return cmp.isValid(null, version);

--- a/src/main/java/org/openrewrite/java/dependencies/search/RepositoryHasDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/search/RepositoryHasDependency.java
@@ -31,7 +31,9 @@ import org.openrewrite.maven.tree.Scope;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @EqualsAndHashCode(callSuper = false)
@@ -107,12 +109,17 @@ public class RepositoryHasDependency extends ScanningRecipe<AtomicBoolean> {
         if (mavenResult != null) {
             Scope requestedScope = scope == null ? null : Scope.fromName(scope);
             List<ResolvedDependency> dependencies = mavenResult.findDependencies(groupIdPattern, artifactIdPattern, requestedScope);
+            Set<String> resolvedGAs = new HashSet<>();
             for (ResolvedDependency dependency : dependencies) {
+                resolvedGAs.add(dependency.getGroupId() + ":" + dependency.getArtifactId());
                 if (versionComparator == null || versionComparator.isValid(null, dependency.getVersion())) {
                     return true;
                 }
             }
             for (Dependency requested : mavenResult.getPom().getRequestedDependencies()) {
+                if (resolvedGAs.contains(requested.getGroupId() + ":" + requested.getArtifactId())) {
+                    continue;
+                }
                 if (matchesRequested(requested, requestedScope, versionComparator)) {
                     return true;
                 }
@@ -122,16 +129,23 @@ public class RepositoryHasDependency extends ScanningRecipe<AtomicBoolean> {
 
         GradleProject gp = tree.getMarkers().findFirst(GradleProject.class).orElse(null);
         if (gp != null) {
+            Set<String> resolvedGAs = new HashSet<>();
             for (GradleDependencyConfiguration c : gp.getConfigurations()) {
                 for (ResolvedDependency resolvedDependency : c.getDirectResolved()) {
                     ResolvedDependency found = resolvedDependency.findDependency(groupIdPattern, artifactIdPattern);
-                    if (found != null && (versionComparator == null || versionComparator.isValid(null, found.getVersion()))) {
-                        return true;
+                    if (found != null) {
+                        resolvedGAs.add(found.getGroupId() + ":" + found.getArtifactId());
+                        if (versionComparator == null || versionComparator.isValid(null, found.getVersion())) {
+                            return true;
+                        }
                     }
                 }
             }
             for (GradleDependencyConfiguration c : gp.getConfigurations()) {
                 for (Dependency requested : c.getRequested()) {
+                    if (resolvedGAs.contains(requested.getGroupId() + ":" + requested.getArtifactId())) {
+                        continue;
+                    }
                     if (matchesRequested(requested, null, versionComparator)) {
                         return true;
                     }
@@ -161,10 +175,10 @@ public class RepositoryHasDependency extends ScanningRecipe<AtomicBoolean> {
     }
 
     private static boolean versionMatches(@Nullable String version, @Nullable VersionComparator cmp) {
-        if (cmp == null || version == null) {
+        if (cmp == null) {
             return true;
         }
-        if (version.startsWith("${")) {
+        if (version == null || version.startsWith("${")) {
             return false;
         }
         return cmp.isValid(null, version);

--- a/src/test/java/org/openrewrite/java/dependencies/search/ModuleHasDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/ModuleHasDependencyTest.java
@@ -510,6 +510,44 @@ class ModuleHasDependencyTest implements RewriteTest {
               )
             );
         }
+
+        @Language("xml")
+        private final static String MavenBomManagedOutOfRange = """
+          <project>
+            <groupId>com.example</groupId>
+            <artifactId>foo</artifactId>
+            <version>1.0.0</version>
+            <dependencyManagement>
+              <dependencies>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-dependencies</artifactId>
+                  <version>3.0.0</version>
+                  <type>pom</type>
+                  <scope>import</scope>
+                </dependency>
+              </dependencies>
+            </dependencyManagement>
+            <dependencies>
+              <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+              </dependency>
+            </dependencies>
+          </project>
+          """;
+
+        @Test
+        void mavenVersionRangeDoesNotMatchBomManagedDependencyWhenResolvedIsOutOfRange() {
+            // Regression for rewrite-third-party#76: BOM-managed version (null on requested) must not match the range.
+            rewriteRun(
+              spec -> spec.recipe(new ModuleHasDependency(GroupId, ArtifactId, null, "[5.0,6.0)", null)),
+              mavenProject("project-maven",
+                pomXml(MavenBomManagedOutOfRange),
+                java(MavenJava)
+              )
+            );
+        }
     }
 
 @Nested

--- a/src/test/java/org/openrewrite/java/dependencies/search/ModuleHasDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/ModuleHasDependencyTest.java
@@ -467,10 +467,7 @@ class ModuleHasDependencyTest implements RewriteTest {
 
         @Test
         void gradleRequestedWithoutVersionAndConstraintDoesNotMatch() {
-            // Resolution fails (no repositories), so the requested fallback fires. The declared
-            // dependency omits a version (supplied elsewhere by a platform/constraint), so its
-            // requested version is null and must NOT match the supplied version constraint (same
-            // treatment as a ${...} property reference).
+            // Force resolution failure (no repositories), so the requested fallback fires.
             rewriteRun(
               spec -> spec.recipe(new ModuleHasDependency(GroupId, ArtifactId, null, "[1.0,)", null)),
               mavenProject("project-gradle",
@@ -504,9 +501,7 @@ class ModuleHasDependencyTest implements RewriteTest {
 
         @Test
         void gradleVersionRangeDoesNotMatchDeclaredWhenResolvedVersionIsOutOfRange() {
-            // Declared spring-beans 5.3.0 (in range), but resolutionStrategy forces resolved 6.0.0
-            // (out of range). The resolved version is the source of truth, so the declared-dependency
-            // fallback must be skipped for an already-resolved coordinate and [5.0,6.0) must NOT match.
+            // The declared-dependency fallback must be skipped for an already-resolved coordinate (resolutionStrategy).
             rewriteRun(
               spec -> spec.recipe(new ModuleHasDependency(GroupId, ArtifactId, null, "[5.0,6.0)", null)),
               mavenProject("project-gradle",

--- a/src/test/java/org/openrewrite/java/dependencies/search/ModuleHasDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/ModuleHasDependencyTest.java
@@ -454,6 +454,67 @@ class ModuleHasDependencyTest implements RewriteTest {
               )
             );
         }
+
+        @Language("groovy")
+        private final static String GradleNoRepositoriesNoVersion = """
+          plugins {
+            id 'java-library'
+          }
+          dependencies {
+            implementation 'org.springframework:spring-beans'
+          }
+          """;
+
+        @Test
+        void gradleRequestedWithoutVersionAndConstraintDoesNotMatch() {
+            // Resolution fails (no repositories), so the requested fallback fires. The declared
+            // dependency omits a version (supplied elsewhere by a platform/constraint), so its
+            // requested version is null and must NOT match the supplied version constraint (same
+            // treatment as a ${...} property reference).
+            rewriteRun(
+              spec -> spec.recipe(new ModuleHasDependency(GroupId, ArtifactId, null, "[1.0,)", null)),
+              mavenProject("project-gradle",
+                buildGradle(GradleNoRepositoriesNoVersion),
+                java(GradleJava)
+              )
+            );
+        }
+    }
+
+    @Nested
+    class WhenResolvedVersionIsSourceOfTruth {
+
+        @Language("groovy")
+        private final static String GradleForcedOutOfRange = """
+          plugins {
+            id 'java-library'
+          }
+          repositories {
+            mavenCentral()
+          }
+          configurations.all {
+            resolutionStrategy {
+              force 'org.springframework:spring-beans:6.0.0'
+            }
+          }
+          dependencies {
+            implementation 'org.springframework:spring-beans:5.3.0'
+          }
+          """;
+
+        @Test
+        void gradleVersionRangeDoesNotMatchDeclaredWhenResolvedVersionIsOutOfRange() {
+            // Declared spring-beans 5.3.0 (in range), but resolutionStrategy forces resolved 6.0.0
+            // (out of range). The resolved version is the source of truth, so the declared-dependency
+            // fallback must be skipped for an already-resolved coordinate and [5.0,6.0) must NOT match.
+            rewriteRun(
+              spec -> spec.recipe(new ModuleHasDependency(GroupId, ArtifactId, null, "[5.0,6.0)", null)),
+              mavenProject("project-gradle",
+                buildGradle(GradleForcedOutOfRange),
+                java(GradleJava)
+              )
+            );
+        }
     }
 
 @Nested

--- a/src/test/java/org/openrewrite/java/dependencies/search/RepositoryHasDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/RepositoryHasDependencyTest.java
@@ -15,12 +15,15 @@
  */
 package org.openrewrite.java.dependencies.search;
 
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -81,6 +84,64 @@ class RepositoryHasDependencyTest implements RewriteTest {
                 </project>
                 """
             )
+          )
+        );
+    }
+
+    @Language("java")
+    private final static String GradleJava = """
+      public class AGradle {}
+      """;
+
+    @Test
+    void gradleVersionRangeDoesNotMatchDeclaredWhenResolvedVersionIsOutOfRange() {
+        // Declared spring-beans 5.3.0 (in range), but resolutionStrategy forces resolved 6.0.0
+        // (out of range). The resolved version is the source of truth, so the declared-dependency
+        // fallback must be skipped for an already-resolved coordinate and [5.0,6.0) must NOT match.
+        rewriteRun(
+          spec -> spec.recipe(new RepositoryHasDependency("org.springframework", "spring-beans", null, "[5.0,6.0)")),
+          mavenProject("project-gradle",
+            //language=groovy
+            buildGradle("""
+              plugins {
+                id 'java-library'
+              }
+              repositories {
+                mavenCentral()
+              }
+              configurations.all {
+                resolutionStrategy {
+                  force 'org.springframework:spring-beans:6.0.0'
+                }
+              }
+              dependencies {
+                implementation 'org.springframework:spring-beans:5.3.0'
+              }
+              """),
+            java(GradleJava)
+          )
+        );
+    }
+
+    @Test
+    void gradleRequestedWithoutVersionAndConstraintDoesNotMatch() {
+        // Resolution fails (no repositories), so the requested fallback fires. The declared
+        // dependency omits a version (supplied elsewhere by a platform/constraint), so its
+        // requested version is null and must NOT match the supplied version constraint (same
+        // treatment as a ${...} property reference).
+        rewriteRun(
+          spec -> spec.recipe(new RepositoryHasDependency("org.springframework", "spring-beans", null, "[1.0,)")),
+          mavenProject("project-gradle",
+            //language=groovy
+            buildGradle("""
+              plugins {
+                id 'java-library'
+              }
+              dependencies {
+                implementation 'org.springframework:spring-beans'
+              }
+              """),
+            java(GradleJava)
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/dependencies/search/RepositoryHasDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/RepositoryHasDependencyTest.java
@@ -122,6 +122,41 @@ class RepositoryHasDependencyTest implements RewriteTest {
     }
 
     @Test
+    void mavenVersionRangeDoesNotMatchBomManagedDependencyWhenResolvedIsOutOfRange() {
+        // Regression for rewrite-third-party#76: BOM-managed version (null on requested) must not match the range.
+        rewriteRun(
+          spec -> spec.recipe(new RepositoryHasDependency("org.springframework", "spring-beans", null, "[5.0,6.0)")),
+          mavenProject("project-maven",
+            //language=xml
+            pomXml("""
+              <project>
+                <groupId>com.example</groupId>
+                <artifactId>foo</artifactId>
+                <version>1.0.0</version>
+                <dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-dependencies</artifactId>
+                      <version>3.0.0</version>
+                      <type>pom</type>
+                      <scope>import</scope>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-beans</artifactId>
+                  </dependency>
+                </dependencies>
+              </project>
+              """)
+          )
+        );
+    }
+
+    @Test
     void gradleRequestedWithoutVersionAndConstraintDoesNotMatch() {
         // Force resolution failure (no repositories), so the requested fallback fires.
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/dependencies/search/RepositoryHasDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/search/RepositoryHasDependencyTest.java
@@ -95,9 +95,7 @@ class RepositoryHasDependencyTest implements RewriteTest {
 
     @Test
     void gradleVersionRangeDoesNotMatchDeclaredWhenResolvedVersionIsOutOfRange() {
-        // Declared spring-beans 5.3.0 (in range), but resolutionStrategy forces resolved 6.0.0
-        // (out of range). The resolved version is the source of truth, so the declared-dependency
-        // fallback must be skipped for an already-resolved coordinate and [5.0,6.0) must NOT match.
+        // The declared-dependency fallback must be skipped for an already-resolved coordinate (resolutionStrategy).
         rewriteRun(
           spec -> spec.recipe(new RepositoryHasDependency("org.springframework", "spring-beans", null, "[5.0,6.0)")),
           mavenProject("project-gradle",
@@ -125,10 +123,7 @@ class RepositoryHasDependencyTest implements RewriteTest {
 
     @Test
     void gradleRequestedWithoutVersionAndConstraintDoesNotMatch() {
-        // Resolution fails (no repositories), so the requested fallback fires. The declared
-        // dependency omits a version (supplied elsewhere by a platform/constraint), so its
-        // requested version is null and must NOT match the supplied version constraint (same
-        // treatment as a ${...} property reference).
+        // Force resolution failure (no repositories), so the requested fallback fires.
         rewriteRun(
           spec -> spec.recipe(new RepositoryHasDependency("org.springframework", "spring-beans", null, "[1.0,)")),
           mavenProject("project-gradle",


### PR DESCRIPTION
## What

- PR #179 (`ad8dbec`) extended `ModuleHasDependency` and `RepositoryHasDependency` to also match against **requested/declared** dependencies, so they still match when dependency resolution fails (e.g. no repositories configured). As reported in [`rewrite-third-party#76`](https://github.com/openrewrite/rewrite-third-party/issues/76), this introduced false positives whenever a **version range** is supplied:

- If the project resolves, the resolved version is the source of truth. But the new code unconditionally also walked the declared dependencies, and the literal declared version string can satisfy the comparator even when the resolved version does not (BOM-managed versions, Gradle `resolutionStrategy.force`, platform alignment, etc.).
- A `null` declared version (`versionMatches(null, cmp)`) silently matched any constraint.

## Fix

- 1. **Trust resolved over declared.** While iterating resolved dependencies, accumulate the set of resolved `groupId:artifactId` coordinates. When iterating requested/declared dependencies, skip any whose GA is already resolved. This preserves the "match on declared when not resolved" behaviour from #179 while preventing the version-range false positive.
2. **Tighten `versionMatches`.** A `null` declared version no longer auto-matches when a version constraint is supplied (same treatment as a `${...}` property reference).

Applied identically to both `ModuleHasDependency` and `RepositoryHasDependency`.

## Tests

- Existing #179 tests (`gradleMatchesOnRequested`, `mavenMatchesOnRequested`, `gradleVersionRangeOnRequestedDoesNotMatchWhenOutOfRange`) still pass.
- New `gradleVersionRangeDoesNotMatchDeclaredWhenResolvedVersionIsOutOfRange` (rule 1): `resolutionStrategy.force` resolves out-of-range while the declared version is in-range → no match. Verified to fail without the dedup fix.
- New `gradleRequestedWithoutVersionAndConstraintDoesNotMatch` (rule 2): declared dep with no version + a constraint → no match. Verified to fail without the `versionMatches` change.
- Both mirrored in `ModuleHasDependencyTest` and `RepositoryHasDependencyTest`.

Note: a Maven analogue for rule 1 is not included — in Maven an explicit declared `<version>` on a direct dependency always wins over `<dependencyManagement>`/BOM, so the resolved version equals the declared version and no divergence (hence no false positive) is reproducible for a direct dep. The divergence is a Gradle phenomenon (force/platform/alignment).

`./gradlew check` passes.