### PR TITLE
Fix RemoveDependency.unlessUsing for multi-module Maven projects

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
@@ -21,13 +21,15 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.maven.tree.MavenResolutionResult;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
-public class RemoveDependency extends ScanningRecipe<Map<JavaProject, Boolean>> {
+public class RemoveDependency extends ScanningRecipe<RemoveDependency.Accumulator> {
     @Option(displayName = "Group ID",
             description = "The first part of a dependency coordinate `com.google.guava:guava:VERSION`. This can be a glob expression.",
             example = "com.fasterxml.jackson*")
@@ -68,13 +70,18 @@ public class RemoveDependency extends ScanningRecipe<Map<JavaProject, Boolean>> 
     String description = "For Gradle project, removes a single dependency from the dependencies section of the `build.gradle`.\n" +
                "For Maven project, removes a single dependency from the `<dependencies>` section of the pom.xml.";
 
-    @Override
-    public Map<JavaProject, Boolean> getInitialValue(ExecutionContext ctx) {
-        return new HashMap<>();
+    public static class Accumulator {
+        final Map<JavaProject, Boolean> projectToInUse = new HashMap<>();
+        final Map<UUID, JavaProject> mavenIdToProject = new HashMap<>();
     }
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getScanner(Map<JavaProject, Boolean> projectToInUse) {
+    public Accumulator getInitialValue(ExecutionContext ctx) {
+        return new Accumulator();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
         if (unlessUsing == null) {
             return TreeVisitor.noop();
         }
@@ -83,15 +90,19 @@ public class RemoveDependency extends ScanningRecipe<Map<JavaProject, Boolean>> 
             @Override
             public Tree preVisit(Tree tree, ExecutionContext ctx) {
                 stopAfterPreVisit();
-                tree.getMarkers().findFirst(JavaProject.class).ifPresent(javaProject ->
-                    projectToInUse.compute(javaProject, (jp, foundSoFar) -> Boolean.TRUE.equals(foundSoFar) || tree != usesType.visit(tree, ctx)));
+                tree.getMarkers().findFirst(JavaProject.class).ifPresent(javaProject -> {
+                    acc.projectToInUse.compute(javaProject, (jp, foundSoFar) ->
+                            Boolean.TRUE.equals(foundSoFar) || tree != usesType.visit(tree, ctx));
+                    tree.getMarkers().findFirst(MavenResolutionResult.class).ifPresent(mrr ->
+                            acc.mavenIdToProject.put(mrr.getId(), javaProject));
+                });
                 return tree;
             }
         };
     }
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor(Map<JavaProject, Boolean> projectToInUse) {
+    public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
         return new TreeVisitor<Tree, ExecutionContext>() {
             final TreeVisitor<?, ExecutionContext> gradleRemoveDep = new org.openrewrite.gradle.RemoveDependency(groupId, artifactId, configuration).getVisitor();
             final TreeVisitor<?, ExecutionContext> mavenRemoveDep = new org.openrewrite.maven.RemoveDependency(groupId, artifactId, scope).getVisitor();
@@ -103,7 +114,11 @@ public class RemoveDependency extends ScanningRecipe<Map<JavaProject, Boolean>> 
                 }
                 if (unlessUsing != null) {
                     JavaProject jp = tree.getMarkers().findFirst(JavaProject.class).orElse(null);
-                    if (jp == null || Boolean.TRUE.equals(projectToInUse.get(jp))) {
+                    if (jp == null || Boolean.TRUE.equals(acc.projectToInUse.get(jp))) {
+                        return tree;
+                    }
+                    MavenResolutionResult mrr = tree.getMarkers().findFirst(MavenResolutionResult.class).orElse(null);
+                    if (mrr != null && anyDescendantPreservesDependency(mrr, acc)) {
                         return tree;
                     }
                 }
@@ -117,5 +132,23 @@ public class RemoveDependency extends ScanningRecipe<Map<JavaProject, Boolean>> 
                 return tree;
             }
         };
+    }
+
+    /**
+     * Keep this pom's `<dependency>` declaration if any descendant module in the reactor uses the
+     * `unlessUsing` type. A descendant whose Java sources reference the type may rely on this pom
+     * supplying the dependency via inheritance.
+     */
+    private boolean anyDescendantPreservesDependency(MavenResolutionResult mrr, Accumulator acc) {
+        for (MavenResolutionResult child : mrr.getModules()) {
+            JavaProject childJp = acc.mavenIdToProject.get(child.getId());
+            if (childJp != null && Boolean.TRUE.equals(acc.projectToInUse.get(childJp))) {
+                return true;
+            }
+            if (anyDescendantPreservesDependency(child, acc)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveDependency.java
@@ -21,11 +21,14 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.maven.tree.Dependency;
 import org.openrewrite.maven.tree.MavenResolutionResult;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+
+import static org.openrewrite.internal.StringUtils.matchesGlob;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -136,16 +139,29 @@ public class RemoveDependency extends ScanningRecipe<RemoveDependency.Accumulato
 
     /**
      * Keep this pom's `<dependency>` declaration if any descendant module in the reactor uses the
-     * `unlessUsing` type. A descendant whose Java sources reference the type may rely on this pom
-     * supplying the dependency via inheritance.
+     * `unlessUsing` type AND does not also declare the dependency itself. A descendant that
+     * self-declares the dependency in its own pom is unaffected by removing it from an ancestor,
+     * so it should not block removal.
      */
     private boolean anyDescendantPreservesDependency(MavenResolutionResult mrr, Accumulator acc) {
         for (MavenResolutionResult child : mrr.getModules()) {
             JavaProject childJp = acc.mavenIdToProject.get(child.getId());
-            if (childJp != null && Boolean.TRUE.equals(acc.projectToInUse.get(childJp))) {
+            if (childJp != null && Boolean.TRUE.equals(acc.projectToInUse.get(childJp)) && !declaresDependency(child)) {
                 return true;
             }
             if (anyDescendantPreservesDependency(child, acc)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean declaresDependency(MavenResolutionResult mrr) {
+        // Look at the raw `requested` pom — the as-written `<dependencies>` of this module only,
+        // excluding inheritance from a parent pom. A module that inherits the dep from the parent
+        // we may be modifying should still block removal.
+        for (Dependency d : mrr.getPom().getRequested().getDependencies()) {
+            if (matchesGlob(d.getGroupId(), groupId) && matchesGlob(d.getArtifactId(), artifactId)) {
                 return true;
             }
         }

--- a/src/test/java/org/openrewrite/java/dependencies/RemoveDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RemoveDependencyTest.java
@@ -177,6 +177,258 @@ class RemoveDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    void doNotRemoveSpringRetryWhenRetryTemplateInUse() {
+        rewriteRun(
+          spec -> spec
+            .parser(JavaParser.fromJavaVersion().dependsOn(
+              //language=java
+              """
+                package org.springframework.retry.support;
+                public class RetryTemplate {
+                }
+                """,
+              """
+                package org.springframework.retry.policy;
+                public class SimpleRetryPolicy {
+                }
+                """,
+              """
+                package org.springframework.retry.backoff;
+                public class ExponentialBackOffPolicy {
+                }
+                """
+            ))
+            .recipe(new RemoveDependency("org.springframework.retry", "spring-retry", "org.springframework.retry..*", null, null)),
+          mavenProject("example",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import org.springframework.retry.support.RetryTemplate;
+                  import org.springframework.retry.policy.SimpleRetryPolicy;
+                  import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+
+                  class RetryConfig {
+                      RetryTemplate retryTemplate() {
+                          new SimpleRetryPolicy();
+                          new ExponentialBackOffPolicy();
+                          return new RetryTemplate();
+                      }
+                  }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.retry</groupId>
+                      <artifactId>spring-retry</artifactId>
+                      <version>2.0.0</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveSpringRetryWhenOnlyImportsPresent() {
+        rewriteRun(
+          spec -> spec
+            .parser(JavaParser.fromJavaVersion().dependsOn(
+              //language=java
+              """
+                package org.springframework.retry.support;
+                public class RetryTemplate {
+                }
+                """
+            ))
+            .recipe(new RemoveDependency("org.springframework.retry", "spring-retry", "org.springframework.retry..*", null, null)),
+          mavenProject("example",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import org.springframework.retry.support.RetryTemplate;
+
+                  class RetryConfig {
+                      // imports but no body usage — should still keep the dep
+                  }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.retry</groupId>
+                      <artifactId>spring-retry</artifactId>
+                      <version>2.0.0</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveSpringRetryInMultiModuleWhenChildUsesIt() {
+        rewriteRun(
+          spec -> spec
+            .parser(JavaParser.fromJavaVersion().dependsOn(
+              //language=java
+              """
+                package org.springframework.retry.support;
+                public class RetryTemplate {
+                }
+                """
+            ))
+            .recipe(new RemoveDependency("org.springframework.retry", "spring-retry", "org.springframework.retry..*", null, null)),
+          mavenProject("parent",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1</version>
+                  <packaging>pom</packaging>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.retry</groupId>
+                      <artifactId>spring-retry</artifactId>
+                      <version>2.0.0</version>
+                    </dependency>
+                  </dependencies>
+                  <modules>
+                    <module>child</module>
+                  </modules>
+                </project>
+                """
+            ),
+            mavenProject("child",
+              //language=xml
+              pomXml(
+                """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>parent</artifactId>
+                      <version>1</version>
+                    </parent>
+                    <artifactId>child</artifactId>
+                  </project>
+                  """
+              ),
+              //language=java
+              srcMainJava(
+                java(
+                  """
+                    import org.springframework.retry.support.RetryTemplate;
+
+                    class RetryConfig {
+                        RetryTemplate retryTemplate() {
+                            return new RetryTemplate();
+                        }
+                    }
+                    """
+                )
+              )
+            )
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveSpringRetryWhenDepAndUsageInSameChildModule() {
+        rewriteRun(
+          spec -> spec
+            .parser(JavaParser.fromJavaVersion().dependsOn(
+              //language=java
+              """
+                package org.springframework.retry.support;
+                public class RetryTemplate {
+                }
+                """
+            ))
+            .recipe(new RemoveDependency("org.springframework.retry", "spring-retry", "org.springframework.retry..*", null, null)),
+          mavenProject("parent",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                    <module>child</module>
+                  </modules>
+                </project>
+                """
+            ),
+            mavenProject("child",
+              //language=xml
+              pomXml(
+                """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>parent</artifactId>
+                      <version>1</version>
+                    </parent>
+                    <artifactId>child</artifactId>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework.retry</groupId>
+                        <artifactId>spring-retry</artifactId>
+                        <version>2.0.0</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """
+              ),
+              //language=java
+              srcMainJava(
+                java(
+                  """
+                    import org.springframework.retry.support.RetryTemplate;
+
+                    class RetryConfig {
+                        RetryTemplate retryTemplate() {
+                            return new RetryTemplate();
+                        }
+                    }
+                    """
+                )
+              )
+            )
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-java-dependencies/issues/11")
     @Test
     void doRemoveIfNotInUse() {

--- a/src/test/java/org/openrewrite/java/dependencies/RemoveDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RemoveDependencyTest.java
@@ -429,6 +429,95 @@ class RemoveDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    void removeParentDependencyWhenChildSelfDeclaresAndUses() {
+        rewriteRun(
+          spec -> spec
+            .parser(JavaParser.fromJavaVersion().dependsOn(
+              //language=java
+              """
+                package org.springframework.retry.support;
+                public class RetryTemplate {
+                }
+                """
+            ))
+            .recipe(new RemoveDependency("org.springframework.retry", "spring-retry", "org.springframework.retry..*", null, null)),
+          mavenProject("parent",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1</version>
+                  <packaging>pom</packaging>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.retry</groupId>
+                      <artifactId>spring-retry</artifactId>
+                      <version>2.0.0</version>
+                    </dependency>
+                  </dependencies>
+                  <modules>
+                    <module>child</module>
+                  </modules>
+                </project>
+                """,
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                    <module>child</module>
+                  </modules>
+                </project>
+                """
+            ),
+            mavenProject("child",
+              //language=xml
+              pomXml(
+                """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>parent</artifactId>
+                      <version>1</version>
+                    </parent>
+                    <artifactId>child</artifactId>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework.retry</groupId>
+                        <artifactId>spring-retry</artifactId>
+                        <version>2.0.0</version>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """
+              ),
+              //language=java
+              srcMainJava(
+                java(
+                  """
+                    import org.springframework.retry.support.RetryTemplate;
+
+                    class RetryConfig {
+                        RetryTemplate retryTemplate() {
+                            return new RetryTemplate();
+                        }
+                    }
+                    """
+                )
+              )
+            )
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-java-dependencies/issues/11")
     @Test
     void doRemoveIfNotInUse() {


### PR DESCRIPTION
## Summary

`RemoveDependency`'s `unlessUsing` guard is per-`JavaProject` marker, which corresponds to a single Maven module. In a multi-module reactor the parent pom carries a different `JavaProject` than its children, so type usages found in child modules never gate removal from the parent pom — the `<dependency>` gets stripped from the parent while child modules still rely on inheriting it, producing surprise compile errors in downstream builds.

This came up while looking into a Spring Boot 4 migration failure where `io.moderne.java.spring.boot4.MigrateSpringRetry` (which calls `RemoveDependency: unlessUsing: org.springframework.retry..*` at the end of its recipe list) removed `spring-retry` from a parent pom even though child modules contained extensive `RetryTemplate`/`RetryPolicy`/`BackOffPolicy` usage.

Two commits:

1. **Fix RemoveDependency.unlessUsing for multi-module Maven projects** — scanner now also records `MavenResolutionResult.id -> JavaProject`. When the visitor is about to remove from a pom, it walks `MavenResolutionResult.getModules()` recursively and preserves the dep if any descendant's `JavaProject` shows the type in use.
2. **Allow RemoveDependency to remove ancestor decl when descendants self-declare** — refines the descendant check: a descendant only blocks removal if it uses the type AND does not redeclare the dep directly. A descendant that self-declares is self-sufficient, so the ancestor's declaration is dead weight. The self-declaration check uses the raw `Pom.getRequested().getDependencies()` rather than the resolved/inherited list, so a child that inherits the dep from the very ancestor we're modifying still correctly blocks removal.

## Test plan

Five new tests in `RemoveDependencyTest` (all passing):

- `doNotRemoveSpringRetryWhenRetryTemplateInUse` — single module, body usage → preserved
- `doNotRemoveSpringRetryWhenOnlyImportsPresent` — single module, imports only → preserved
- `doNotRemoveSpringRetryWhenDepAndUsageInSameChildModule` — multi-module, dep + Java in same child → preserved
- `doNotRemoveSpringRetryInMultiModuleWhenChildUsesIt` — **previously failing**, parent has dep, child uses → preserved
- `removeParentDependencyWhenChildSelfDeclaresAndUses` — parent has dep, child redeclares and uses → parent dep removed (commit 2 behavior)

Existing tests continue to pass.