### PR TITLE
Cache delegate recipes per recipe instance to avoid repeated construction

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/AddDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/AddDependency.java
@@ -15,11 +15,15 @@
  */
 package org.openrewrite.java.dependencies;
 
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.maven.tree.Scope;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -141,10 +145,13 @@ public class AddDependency extends ScanningRecipe<AddDependency.Accumulator> {
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
         return new TreeVisitor<Tree, ExecutionContext>() {
+            final TreeVisitor<?, ExecutionContext> gradleAddDep = gradleAddDep().getScanner(acc.gradleAccumulator);
+            final TreeVisitor<?, ExecutionContext> mavenAddDep = mavenAddDep().getScanner(acc.mavenAccumulator);
+
             @Override
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
-                gradleAddDep().getScanner(acc.gradleAccumulator).visit(tree, ctx);
-                mavenAddDep().getScanner(acc.mavenAccumulator).visit(tree, ctx);
+                gradleAddDep.visit(tree, ctx);
+                mavenAddDep.visit(tree, ctx);
                 return tree;
             }
         };
@@ -184,20 +191,36 @@ public class AddDependency extends ScanningRecipe<AddDependency.Accumulator> {
         org.openrewrite.maven.AddDependency.Scanned mavenAccumulator;
     }
 
+    @Getter(AccessLevel.NONE)
+    private final transient AtomicReference<org.openrewrite.gradle.AddDependency> gradleDelegate = new AtomicReference<>();
+
+    @Getter(AccessLevel.NONE)
+    private final transient AtomicReference<org.openrewrite.maven.AddDependency> mavenDelegate = new AtomicReference<>();
+
     private org.openrewrite.gradle.AddDependency gradleAddDep() {
-        String configurationName = null;
-        if(configuration != null) {
-            configurationName = configuration;
-        } else if(scope != null) {
-            configurationName = Scope.asGradleConfigurationName(Scope.fromName(scope));
+        org.openrewrite.gradle.AddDependency recipe = gradleDelegate.get();
+        if (recipe == null) {
+            String configurationName = null;
+            if(configuration != null) {
+                configurationName = configuration;
+            } else if(scope != null) {
+                configurationName = Scope.asGradleConfigurationName(Scope.fromName(scope));
+            }
+            recipe = new org.openrewrite.gradle.AddDependency(groupId, artifactId, version, versionPattern,
+                    configurationName, onlyIfUsing, classifier, extension, familyPattern, acceptTransitive);
+            gradleDelegate.set(recipe);
         }
-        return new org.openrewrite.gradle.AddDependency(groupId, artifactId, version, versionPattern,
-                configurationName, onlyIfUsing, classifier, extension, familyPattern, acceptTransitive);
+        return recipe;
     }
 
     private org.openrewrite.maven.AddDependency mavenAddDep() {
-        return new org.openrewrite.maven.AddDependency(groupId, artifactId, version != null ? version : "latest.release",
-                versionPattern, scope, releasesOnly, onlyIfUsing, type, classifier, optional, familyPattern,
-                acceptTransitive);
+        org.openrewrite.maven.AddDependency recipe = mavenDelegate.get();
+        if (recipe == null) {
+            recipe = new org.openrewrite.maven.AddDependency(groupId, artifactId, version != null ? version : "latest.release",
+                    versionPattern, scope, releasesOnly, onlyIfUsing, type, classifier, optional, familyPattern,
+                    acceptTransitive);
+            mavenDelegate.set(recipe);
+        }
+        return recipe;
     }
 }

--- a/src/main/java/org/openrewrite/java/dependencies/ChangeDependency.java
+++ b/src/main/java/org/openrewrite/java/dependencies/ChangeDependency.java
@@ -15,12 +15,15 @@
  */
 package org.openrewrite.java.dependencies;
 
+import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
 
@@ -152,16 +155,32 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
         };
     }
 
+    @Getter(AccessLevel.NONE)
+    private final transient AtomicReference<org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId> mavenDelegate = new AtomicReference<>();
+
+    @Getter(AccessLevel.NONE)
+    private final transient AtomicReference<org.openrewrite.gradle.ChangeDependency> gradleDelegate = new AtomicReference<>();
+
     org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId getMavenChangeDependency() {
-        return new org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId(
-                oldGroupId, oldArtifactId, newGroupId, newArtifactId,
-                newVersion, versionPattern, overrideManagedVersion, changeManagedDependency);
+        org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId recipe = mavenDelegate.get();
+        if (recipe == null) {
+            recipe = new org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId(
+                    oldGroupId, oldArtifactId, newGroupId, newArtifactId,
+                    newVersion, versionPattern, overrideManagedVersion, changeManagedDependency);
+            mavenDelegate.set(recipe);
+        }
+        return recipe;
     }
 
     org.openrewrite.gradle.ChangeDependency getGradleChangeDependency() {
-        return new org.openrewrite.gradle.ChangeDependency(
-                oldGroupId, oldArtifactId, newGroupId, newArtifactId,
-                newVersion, versionPattern, overrideManagedVersion, true);
+        org.openrewrite.gradle.ChangeDependency recipe = gradleDelegate.get();
+        if (recipe == null) {
+            recipe = new org.openrewrite.gradle.ChangeDependency(
+                    oldGroupId, oldArtifactId, newGroupId, newArtifactId,
+                    newVersion, versionPattern, overrideManagedVersion, true);
+            gradleDelegate.set(recipe);
+        }
+        return recipe;
     }
 
     @Data

--- a/src/main/java/org/openrewrite/java/dependencies/UpgradeDependencyVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/UpgradeDependencyVersion.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.dependencies;
 
+import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -23,6 +24,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
 
@@ -139,12 +141,28 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         };
     }
 
+    @Getter(AccessLevel.NONE)
+    private final transient AtomicReference<org.openrewrite.maven.UpgradeDependencyVersion> mavenDelegate = new AtomicReference<>();
+
+    @Getter(AccessLevel.NONE)
+    private final transient AtomicReference<org.openrewrite.gradle.UpgradeDependencyVersion> gradleDelegate = new AtomicReference<>();
+
     org.openrewrite.maven.UpgradeDependencyVersion getUpgradeMavenDependencyVersion() {
-        return new org.openrewrite.maven.UpgradeDependencyVersion(groupId, artifactId, newVersion, versionPattern, overrideManagedVersion, retainVersions);
+        org.openrewrite.maven.UpgradeDependencyVersion recipe = mavenDelegate.get();
+        if (recipe == null) {
+            recipe = new org.openrewrite.maven.UpgradeDependencyVersion(groupId, artifactId, newVersion, versionPattern, overrideManagedVersion, retainVersions);
+            mavenDelegate.set(recipe);
+        }
+        return recipe;
     }
 
     public org.openrewrite.gradle.UpgradeDependencyVersion getUpgradeGradleDependencyVersion() {
-        return new org.openrewrite.gradle.UpgradeDependencyVersion(groupId, artifactId, newVersion, versionPattern);
+        org.openrewrite.gradle.UpgradeDependencyVersion recipe = gradleDelegate.get();
+        if (recipe == null) {
+            recipe = new org.openrewrite.gradle.UpgradeDependencyVersion(groupId, artifactId, newVersion, versionPattern);
+            gradleDelegate.set(recipe);
+        }
+        return recipe;
     }
 
     @Data

--- a/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java
@@ -15,11 +15,15 @@
  */
 package org.openrewrite.java.dependencies;
 
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.maven.AddManagedDependency;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -154,11 +158,27 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
         };
     }
 
+    @Getter(AccessLevel.NONE)
+    private final transient AtomicReference<org.openrewrite.gradle.UpgradeTransitiveDependencyVersion> gradleDelegate = new AtomicReference<>();
+
+    @Getter(AccessLevel.NONE)
+    private final transient AtomicReference<org.openrewrite.maven.UpgradeTransitiveDependencyVersion> mavenDelegate = new AtomicReference<>();
+
     private org.openrewrite.gradle.UpgradeTransitiveDependencyVersion getGradleUpgradeTransitive() {
-        return new org.openrewrite.gradle.UpgradeTransitiveDependencyVersion(groupId, artifactId, version, versionPattern, because, null);
+        org.openrewrite.gradle.UpgradeTransitiveDependencyVersion recipe = gradleDelegate.get();
+        if (recipe == null) {
+            recipe = new org.openrewrite.gradle.UpgradeTransitiveDependencyVersion(groupId, artifactId, version, versionPattern, because, null);
+            gradleDelegate.set(recipe);
+        }
+        return recipe;
     }
 
     private org.openrewrite.maven.UpgradeTransitiveDependencyVersion getMavenUpgradeTransitive() {
-        return new org.openrewrite.maven.UpgradeTransitiveDependencyVersion(groupId, artifactId, version, scope, type, classifier, versionPattern, releasesOnly, onlyIfUsing, addToRootPom, because);
+        org.openrewrite.maven.UpgradeTransitiveDependencyVersion recipe = mavenDelegate.get();
+        if (recipe == null) {
+            recipe = new org.openrewrite.maven.UpgradeTransitiveDependencyVersion(groupId, artifactId, version, scope, type, classifier, versionPattern, releasesOnly, onlyIfUsing, addToRootPom, because);
+            mavenDelegate.set(recipe);
+        }
+        return recipe;
     }
 }


### PR DESCRIPTION
## Motivation

The Gradle/Maven dependency wrapper recipes — `AddDependency`, `ChangeDependency`, `UpgradeDependencyVersion`, and `UpgradeTransitiveDependencyVersion` — each delegate to a Gradle and a Maven `ScanningRecipe`. Until now they constructed a fresh delegate instance on *every* `getInitialValue`, `getScanner`, `getVisitor`, and `validate` call, and `AddDependency.getScanner` even constructed its delegates once per source file from inside the scanner's `visit`. Every `ScanningRecipe` constructor computes `"org.openrewrite.recipe.acc." + UUID.randomUUID()` for its accumulator-message key, and `UUID.randomUUID()` draws from `SecureRandom`. In profiles of recipe-heavy runs this `SecureRandom` draw dominated, with these wrapper recipes accounting for nearly all of the cost.

The fix is to build each delegate at most once and reuse it. The delegate recipe is derived from the wrapper's options, so it logically belongs to the wrapper recipe **instance**, not to the run-scoped accumulator. Each wrapper memoizes its two delegates lazily in a `final transient AtomicReference` — `final` and initialized so it is excluded from the Lombok-generated constructor, `transient` so it stays out of `equals`/`hashCode`, and `AtomicReference` for safe publication under concurrent `getScanner`/`getVisitor` calls. The `Accumulator` types are deliberately left unchanged so their public constructors keep working for downstream callers that build them directly (for example `rewrite-spring`, which constructs `UpgradeDependencyVersion.Accumulator` itself).

Caching on the instance rather than the accumulator also avoids a subtle correctness trap: `rewrite-spring` reuses a single accumulator across two different `UpgradeDependencyVersion` instances — an empty-option one for scanning and a real-option one for editing — so a delegate cached on the accumulator would apply the wrong options during the edit phase. Instance memoization gives each wrapper its own correctly-configured delegate.

## Summary

- Each wrapper memoizes its Gradle and Maven delegate `ScanningRecipe` lazily on the recipe instance via a `final transient AtomicReference`, reused across the scanning and editing phases.
- Delegate construction per wrapper per run drops from "once per phase (and, for `AddDependency`, per source file)" to at most one Gradle and one Maven delegate per wrapper instance.
- Hoisted `AddDependency.getScanner`'s delegate-scanner creation out of the per-source-file `visit`.
- `Accumulator` types are unchanged, preserving their public constructors.

## Test plan

- Re-ran `AddDependencyTest`, `ChangeDependencyTest`, and `UpgradeDependencyVersionTest` — green before and after.
- Ran the full test suite — green.
- Published to Maven Local and rebuilt `rewrite-spring`, which constructs `UpgradeDependencyVersion.Accumulator` directly — compiles successfully, confirming the public accumulator API is preserved.