### PR TITLE
Update findRelocatedIonJava test for new relocation context

### DIFF
--- a/src/test/java/org/openrewrite/java/dependencies/RelocatedDependencyCheckTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RelocatedDependencyCheckTest.java
@@ -154,7 +154,8 @@ class RelocatedDependencyCheckTest implements RewriteTest {
         void findRelocatedIonJava() {
             rewriteRun(
               recipe -> recipe.dataTable(RelocatedDependencyReport.Row.class, rows -> assertThat(rows).containsExactly(
-                new RelocatedDependencyReport.Row("software.amazon.ion", "ion-java", "com.amazon.ion", "ion-java", null)
+                new RelocatedDependencyReport.Row("software.amazon.ion", "ion-java", "com.amazon.ion", "ion-java",
+                  "From version 1.4.0 onward, Amazon Ion for Java moved to the new group id and Java package name \"com.amazon.ion\". The legacy \"software.amazon.ion\" group id is deprecated. See https://amazon-ion.github.io/ion-docs/news/2020/01/15/software.amazon.ion-deprecated.html")
               )),
               //language=xml
               pomXml(
@@ -180,7 +181,7 @@ class RelocatedDependencyCheckTest implements RewriteTest {
                     <artifactId>rewrite-example</artifactId>
                     <version>1.0-SNAPSHOT</version>
                     <dependencies>
-                      <!--~~(Relocated to com.amazon.ion:ion-java)~~>--><dependency>
+                      <!--~~(Relocated to com.amazon.ion:ion-java as per "From version 1.4.0 onward, Amazon Ion for Java moved to the new group id and Java package name "com.amazon.ion". The legacy "software.amazon.ion" group id is deprecated. See https://amazon-ion.github.io/ion-docs/news/2020/01/15/software.amazon.ion-deprecated.html")~~>--><dependency>
                         <groupId>software.amazon.ion</groupId>
                         <artifactId>ion-java</artifactId>
                         <version>1.5.1</version>


### PR DESCRIPTION
## Problem
Scheduled CI failed in [run 28122079598](https://github.com/openrewrite/rewrite-java-dependencies/actions/runs/28122079598): `RelocatedDependencyCheckTest.Maven.findRelocatedIonJava()` expected `context=null` and a marker comment without context, but the recipe now emits a populated context.

## Root cause
The automated [`[Auto] Old GroupId migrations as of 2026-06-23T1723`](https://github.com/openrewrite/rewrite-java-dependencies/commit/5253cf5) commit added a context note to the `software.amazon.ion:ion-java` relocation in `migrations.csv`. `RelocatedDependencyCheck` surfaces that context in both:
- the `RelocatedDependencyReport.Row` data table, and
- the inline `~~(Relocated to … as per "…")~~` search-result marker.

The test wasn't updated alongside the data change.

## Fix
Update both the data-table row expectation and the expected marker comment to include the ion-java relocation context string from `migrations.csv`. Verified with `./gradlew test --tests RelocatedDependencyCheckTest` (green).