### PR TITLE
Keep direct dependencies whose scope or exclusions differ from the transitive one

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/RemoveRedundantDependencies.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveRedundantDependencies.java
@@ -221,7 +221,7 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                         acc.transitivesByProjectAndScope.getOrDefault(projectId, emptyMap());
 
                 for (GradleDependencyConfiguration conf : gradle.getConfigurations()) {
-                    Set<TransitiveDependency> transitives = getCompatibleTransitives(
+                    Set<TransitiveDependency> transitives = getCompatibleGradleTransitives(
                             scopeToTransitives, conf.getName());
                     if (transitives.isEmpty()) {
                         continue;
@@ -291,10 +291,7 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                 return false;
             }
 
-            /**
-             * Get Gradle transitives from this configuration and any broader ones.
-             */
-            private Set<TransitiveDependency> getCompatibleTransitives(
+            private Set<TransitiveDependency> getCompatibleGradleTransitives(
                     Map<String, Set<TransitiveDependency>> scopeToTransitives,
                     String targetScope) {
 

--- a/src/main/java/org/openrewrite/java/dependencies/RemoveRedundantDependencies.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveRedundantDependencies.java
@@ -60,11 +60,6 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
         Map<String, Map<String, Set<TransitiveDependency>>> transitivesByProjectAndScope;
     }
 
-    /**
-     * A dependency provided transitively by a matched parent dependency, together with the exclusions
-     * that are already in effect for it along that transitive path. Both the coordinate and the
-     * exclusions must match a direct declaration for it to be considered redundant.
-     */
     @Value
     public static class TransitiveDependency {
         ResolvedGroupArtifactVersion gav;
@@ -205,73 +200,76 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                     return tree;
                 }
 
-                SourceFile sf = (SourceFile) tree;
-                Tree result = sf;
-
-                // Handle Gradle
-                Optional<GradleProject> gradleOpt = sf.getMarkers().findFirst(GradleProject.class);
+                Optional<GradleProject> gradleOpt = tree.getMarkers().findFirst(GradleProject.class);
                 if (gradleOpt.isPresent()) {
                     GradleProject gradle = gradleOpt.get();
-                    String projectId = gradle.getGroup() + ":" + gradle.getName();
-                    Map<String, Set<TransitiveDependency>> scopeToTransitives =
-                            acc.transitivesByProjectAndScope.getOrDefault(projectId, emptyMap());
+                    return handleGradle(ctx, gradle, tree);
+                }
 
-                    for (GradleDependencyConfiguration conf : gradle.getConfigurations()) {
-                        Set<TransitiveDependency> transitives = getCompatibleTransitives(
-                                scopeToTransitives, conf.getName());
-                        if (transitives.isEmpty()) {
-                            continue;
+                Optional<MavenResolutionResult> mavenOpt = tree.getMarkers().findFirst(MavenResolutionResult.class);
+                if (mavenOpt.isPresent()) {
+                    MavenResolutionResult maven = mavenOpt.get();
+                    return handleMaven(ctx, maven, tree);
+                }
+
+                return tree;
+            }
+
+            private @Nullable Tree handleGradle(ExecutionContext ctx, GradleProject gradle, Tree result) {
+                String projectId = gradle.getGroup() + ":" + gradle.getName();
+                Map<String, Set<TransitiveDependency>> scopeToTransitives =
+                        acc.transitivesByProjectAndScope.getOrDefault(projectId, emptyMap());
+
+                for (GradleDependencyConfiguration conf : gradle.getConfigurations()) {
+                    Set<TransitiveDependency> transitives = getCompatibleTransitives(
+                            scopeToTransitives, conf.getName());
+                    if (transitives.isEmpty()) {
+                        continue;
+                    }
+
+                    for (ResolvedDependency dep : conf.getResolved()) {
+                        if (dep.isDirect() &&
+                                doesNotMatchArguments(dep) &&
+                                isRedundant(dep, transitives)) {
+                            // This direct dependency is transitively provided, remove it
+                            // Don't specify configuration - Gradle's resolved config names differ from declaration names
+                            result = new RemoveDependency(
+                                    dep.getGroupId(), dep.getArtifactId(), null, null, null)
+                                    .getVisitor().visit(result, ctx);
                         }
+                    }
+                }
+                return result;
+            }
 
-                        for (ResolvedDependency dep : conf.getResolved()) {
-                            if (dep.isDirect() &&
-                                    doesNotMatchArguments(dep) &&
-                                    isRedundant(dep, transitives)) {
-                                // This direct dependency is transitively provided, remove it
-                                // Don't specify configuration - Gradle's resolved config names differ from declaration names
+            private @Nullable Tree handleMaven(ExecutionContext ctx, MavenResolutionResult maven, Tree result) {
+                String projectId = maven.getPom().getGroupId() + ":" + maven.getPom().getArtifactId();
+                Map<String, Set<TransitiveDependency>> scopeToTransitives =
+                        acc.transitivesByProjectAndScope.getOrDefault(projectId, emptyMap());
+
+                // A direct dependency appears under every scope bucket it is visible in; evaluate each
+                // one once using its own effective scope so a wider transitive scope does not falsely
+                // mark a narrower direct declaration as redundant.
+                Set<String> processed = new HashSet<>();
+                for (List<ResolvedDependency> deps : maven.getDependencies().values()) {
+                    for (ResolvedDependency dep : deps) {
+                        if (dep.isDirect() &&
+                                doesNotMatchArguments(dep) &&
+                                processed.add(dep.getGroupId() + ":" + dep.getArtifactId())) {
+                            Scope depScope = Scope.fromName(dep.getRequested().getScope());
+                            Set<TransitiveDependency> transitives = scopeToTransitives.getOrDefault(
+                                    depScope.name().toLowerCase(), emptySet());
+                            if (isRedundant(dep, transitives)) {
+                                // This direct dependency is transitively provided at the same scope and
+                                // with the same exclusions, remove it.
                                 result = new RemoveDependency(
-                                        dep.getGroupId(), dep.getArtifactId(), null, null, null)
+                                        dep.getGroupId(), dep.getArtifactId(), null, null, depScope.name().toLowerCase())
                                         .getVisitor().visit(result, ctx);
                             }
                         }
                     }
-                    return result;
                 }
-
-                // Handle Maven
-                Optional<MavenResolutionResult> mavenOpt = sf.getMarkers().findFirst(MavenResolutionResult.class);
-                if (mavenOpt.isPresent()) {
-                    MavenResolutionResult maven = mavenOpt.get();
-                    String projectId = maven.getPom().getGroupId() + ":" + maven.getPom().getArtifactId();
-                    Map<String, Set<TransitiveDependency>> scopeToTransitives =
-                            acc.transitivesByProjectAndScope.getOrDefault(projectId, emptyMap());
-
-                    // A direct dependency appears under every scope bucket it is visible in; evaluate each
-                    // one once using its own effective scope so a wider transitive scope does not falsely
-                    // mark a narrower direct declaration as redundant.
-                    Set<String> processed = new HashSet<>();
-                    for (List<ResolvedDependency> deps : maven.getDependencies().values()) {
-                        for (ResolvedDependency dep : deps) {
-                            if (dep.isDirect() &&
-                                    doesNotMatchArguments(dep) &&
-                                    processed.add(dep.getGroupId() + ":" + dep.getArtifactId())) {
-                                Scope depScope = Scope.fromName(dep.getRequested().getScope());
-                                Set<TransitiveDependency> transitives = scopeToTransitives.getOrDefault(
-                                        depScope.name().toLowerCase(), emptySet());
-                                if (isRedundant(dep, transitives)) {
-                                    // This direct dependency is transitively provided at the same scope and
-                                    // with the same exclusions, remove it.
-                                    result = new RemoveDependency(
-                                            dep.getGroupId(), dep.getArtifactId(), null, null, depScope.name().toLowerCase())
-                                            .getVisitor().visit(result, ctx);
-                                }
-                            }
-                        }
-                    }
-                    return result;
-                }
-
-                return tree;
+                return result;
             }
 
             private boolean doesNotMatchArguments(ResolvedDependency dep) {
@@ -279,11 +277,6 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                         !StringUtils.matchesGlob(dep.getArtifactId(), artifactId);
             }
 
-            /**
-             * A direct dependency is redundant only when a transitive one matches its coordinate exactly
-             * (group, artifact, version) and carries the same exclusions. Differing exclusions mean removing
-             * the direct declaration would change which transitive dependencies are pulled in.
-             */
             private boolean isRedundant(ResolvedDependency dep, Set<TransitiveDependency> transitives) {
                 Set<GroupArtifact> depExclusions = new HashSet<>(dep.getEffectiveExclusions());
                 for (TransitiveDependency transitive : transitives) {

--- a/src/main/java/org/openrewrite/java/dependencies/RemoveRedundantDependencies.java
+++ b/src/main/java/org/openrewrite/java/dependencies/RemoveRedundantDependencies.java
@@ -50,12 +50,25 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
 
     String description = "Remove explicit dependencies that are already provided transitively by a specified dependency. " +
                 "This recipe downloads and resolves the parent dependency's POM to determine its true transitive " +
-                "dependencies, allowing it to detect redundancies even when both dependencies are explicitly declared.";
+                "dependencies, allowing it to detect redundancies even when both dependencies are explicitly declared. " +
+                "A direct dependency is only removed when the transitive one provides it at the exact same scope and " +
+                "with the same exclusions, so that removing it does not change the effective classpath.";
 
     @Value
     public static class Accumulator {
-        // Map from project identifier -> scope/configuration -> Set of transitive GAVs
-        Map<String, Map<String, Set<ResolvedGroupArtifactVersion>>> transitivesByProjectAndScope;
+        // Map from project identifier -> scope/configuration -> Set of transitive dependencies
+        Map<String, Map<String, Set<TransitiveDependency>>> transitivesByProjectAndScope;
+    }
+
+    /**
+     * A dependency provided transitively by a matched parent dependency, together with the exclusions
+     * that are already in effect for it along that transitive path. Both the coordinate and the
+     * exclusions must match a direct declaration for it to be considered redundant.
+     */
+    @Value
+    public static class TransitiveDependency {
+        ResolvedGroupArtifactVersion gav;
+        Set<GroupArtifact> exclusions;
     }
 
     @Override
@@ -82,7 +95,7 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                                     StringUtils.matchesGlob(dep.getGroupId(), groupId) &&
                                     StringUtils.matchesGlob(dep.getArtifactId(), artifactId)) {
                                 // This is a matching parent dependency, resolve its transitives independently
-                                Set<ResolvedGroupArtifactVersion> transitives = acc.transitivesByProjectAndScope
+                                Set<TransitiveDependency> transitives = acc.transitivesByProjectAndScope
                                         .computeIfAbsent(projectId, k -> new HashMap<>())
                                         .computeIfAbsent(conf.getName(), k -> new HashSet<>());
                                 resolveTransitivesFromPom(
@@ -101,14 +114,18 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                     String projectId = maven.getPom().getGroupId() + ":" + maven.getPom().getArtifactId();
                     MavenPomDownloader downloader = new MavenPomDownloader(ctx);
 
-                    for (Map.Entry<Scope, List<ResolvedDependency>> entry : maven.getDependencies().entrySet()) {
-                        Scope depScope = entry.getKey();
-                        for (ResolvedDependency dep : entry.getValue()) {
+                    // A direct dependency appears under every scope bucket it is visible in, so process
+                    // each matching parent once, keyed by its own effective (declared) scope.
+                    Set<String> processed = new HashSet<>();
+                    for (List<ResolvedDependency> deps : maven.getDependencies().values()) {
+                        for (ResolvedDependency dep : deps) {
                             if (dep.isDirect() &&
                                     StringUtils.matchesGlob(dep.getGroupId(), groupId) &&
-                                    StringUtils.matchesGlob(dep.getArtifactId(), artifactId)) {
+                                    StringUtils.matchesGlob(dep.getArtifactId(), artifactId) &&
+                                    processed.add(dep.getGroupId() + ":" + dep.getArtifactId())) {
                                 // This is a matching parent dependency, resolve its transitives independently
-                                Set<ResolvedGroupArtifactVersion> transitives = acc.transitivesByProjectAndScope
+                                Scope depScope = Scope.fromName(dep.getRequested().getScope());
+                                Set<TransitiveDependency> transitives = acc.transitivesByProjectAndScope
                                         .computeIfAbsent(projectId, k -> new HashMap<>())
                                         .computeIfAbsent(depScope.name().toLowerCase(), k -> new HashSet<>());
                                 resolveTransitivesFromPom(
@@ -132,7 +149,7 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                     List<MavenRepository> repositories,
                     MavenPomDownloader downloader,
                     ExecutionContext ctx,
-                    Set<ResolvedGroupArtifactVersion> transitives) {
+                    Set<TransitiveDependency> transitives) {
                 try {
                     // Ensure we have Maven Central in the repositories
                     List<MavenRepository> effectiveRepos = new ArrayList<>(repositories);
@@ -148,8 +165,9 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                     List<ResolvedDependency> resolved = patchedPom.resolveDependencies(Scope.Compile, downloader, ctx);
 
                     // Collect all dependencies (both direct and transitive of the parent)
+                    Set<ResolvedGroupArtifactVersion> visited = new HashSet<>();
                     for (ResolvedDependency dep : resolved) {
-                        collectAllDependencies(dep, transitives);
+                        collectAllDependencies(dep, transitives, visited);
                     }
                 } catch (MavenDownloadingException | MavenDownloadingExceptions e) {
                     // If we can't download/resolve the POM, fall back to not detecting redundancies
@@ -166,10 +184,12 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                 return patchedPom;
             }
 
-            private void collectAllDependencies(ResolvedDependency dep, Set<ResolvedGroupArtifactVersion> transitives) {
-                if (transitives.add(dep.getGav())) {
+            private void collectAllDependencies(ResolvedDependency dep, Set<TransitiveDependency> transitives,
+                                                Set<ResolvedGroupArtifactVersion> visited) {
+                if (visited.add(dep.getGav())) {
+                    transitives.add(new TransitiveDependency(dep.getGav(), new HashSet<>(dep.getEffectiveExclusions())));
                     for (ResolvedDependency transitive : dep.getDependencies()) {
-                        collectAllDependencies(transitive, transitives);
+                        collectAllDependencies(transitive, transitives, visited);
                     }
                 }
             }
@@ -193,12 +213,12 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                 if (gradleOpt.isPresent()) {
                     GradleProject gradle = gradleOpt.get();
                     String projectId = gradle.getGroup() + ":" + gradle.getName();
-                    Map<String, Set<ResolvedGroupArtifactVersion>> scopeToTransitives =
+                    Map<String, Set<TransitiveDependency>> scopeToTransitives =
                             acc.transitivesByProjectAndScope.getOrDefault(projectId, emptyMap());
 
                     for (GradleDependencyConfiguration conf : gradle.getConfigurations()) {
-                        Set<ResolvedGroupArtifactVersion> transitives = getCompatibleTransitives(
-                                scopeToTransitives, conf.getName(), true);
+                        Set<TransitiveDependency> transitives = getCompatibleTransitives(
+                                scopeToTransitives, conf.getName());
                         if (transitives.isEmpty()) {
                             continue;
                         }
@@ -206,7 +226,7 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                         for (ResolvedDependency dep : conf.getResolved()) {
                             if (dep.isDirect() &&
                                     doesNotMatchArguments(dep) &&
-                                    isInTransitives(dep, transitives)) {
+                                    isRedundant(dep, transitives)) {
                                 // This direct dependency is transitively provided, remove it
                                 // Don't specify configuration - Gradle's resolved config names differ from declaration names
                                 result = new RemoveDependency(
@@ -223,25 +243,28 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                 if (mavenOpt.isPresent()) {
                     MavenResolutionResult maven = mavenOpt.get();
                     String projectId = maven.getPom().getGroupId() + ":" + maven.getPom().getArtifactId();
-                    Map<String, Set<ResolvedGroupArtifactVersion>> scopeToTransitives =
+                    Map<String, Set<TransitiveDependency>> scopeToTransitives =
                             acc.transitivesByProjectAndScope.getOrDefault(projectId, emptyMap());
 
-                    for (Map.Entry<Scope, List<ResolvedDependency>> entry : maven.getDependencies().entrySet()) {
-                        String scope = entry.getKey().name().toLowerCase();
-                        Set<ResolvedGroupArtifactVersion> transitives = getCompatibleTransitives(
-                                scopeToTransitives, scope, false);
-                        if (transitives.isEmpty()) {
-                            continue;
-                        }
-
-                        for (ResolvedDependency dep : entry.getValue()) {
+                    // A direct dependency appears under every scope bucket it is visible in; evaluate each
+                    // one once using its own effective scope so a wider transitive scope does not falsely
+                    // mark a narrower direct declaration as redundant.
+                    Set<String> processed = new HashSet<>();
+                    for (List<ResolvedDependency> deps : maven.getDependencies().values()) {
+                        for (ResolvedDependency dep : deps) {
                             if (dep.isDirect() &&
                                     doesNotMatchArguments(dep) &&
-                                    isInTransitives(dep, transitives)) {
-                                // This direct dependency is transitively provided, remove it
-                                result = new RemoveDependency(
-                                        dep.getGroupId(), dep.getArtifactId(), null, null, scope)
-                                        .getVisitor().visit(result, ctx);
+                                    processed.add(dep.getGroupId() + ":" + dep.getArtifactId())) {
+                                Scope depScope = Scope.fromName(dep.getRequested().getScope());
+                                Set<TransitiveDependency> transitives = scopeToTransitives.getOrDefault(
+                                        depScope.name().toLowerCase(), emptySet());
+                                if (isRedundant(dep, transitives)) {
+                                    // This direct dependency is transitively provided at the same scope and
+                                    // with the same exclusions, remove it.
+                                    result = new RemoveDependency(
+                                            dep.getGroupId(), dep.getArtifactId(), null, null, depScope.name().toLowerCase())
+                                            .getVisitor().visit(result, ctx);
+                                }
                             }
                         }
                     }
@@ -256,13 +279,19 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                         !StringUtils.matchesGlob(dep.getArtifactId(), artifactId);
             }
 
-            private boolean isInTransitives(ResolvedDependency dep, Set<ResolvedGroupArtifactVersion> transitives) {
-                // Check if this dependency's GAV matches any transitive
-                // We match on groupId:artifactId:version exactly
-                for (ResolvedGroupArtifactVersion transitive : transitives) {
-                    if (dep.getGroupId().equals(transitive.getGroupId()) &&
-                            dep.getArtifactId().equals(transitive.getArtifactId()) &&
-                            dep.getVersion().equals(transitive.getVersion())) {
+            /**
+             * A direct dependency is redundant only when a transitive one matches its coordinate exactly
+             * (group, artifact, version) and carries the same exclusions. Differing exclusions mean removing
+             * the direct declaration would change which transitive dependencies are pulled in.
+             */
+            private boolean isRedundant(ResolvedDependency dep, Set<TransitiveDependency> transitives) {
+                Set<GroupArtifact> depExclusions = new HashSet<>(dep.getEffectiveExclusions());
+                for (TransitiveDependency transitive : transitives) {
+                    ResolvedGroupArtifactVersion gav = transitive.getGav();
+                    if (dep.getGroupId().equals(gav.getGroupId()) &&
+                            dep.getArtifactId().equals(gav.getArtifactId()) &&
+                            dep.getVersion().equals(gav.getVersion()) &&
+                            depExclusions.equals(transitive.getExclusions())) {
                         return true;
                     }
                 }
@@ -270,27 +299,23 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
             }
 
             /**
-             * Get transitives from this scope/configuration and any broader ones.
+             * Get Gradle transitives from this configuration and any broader ones.
              */
-            private Set<ResolvedGroupArtifactVersion> getCompatibleTransitives(
-                    Map<String, Set<ResolvedGroupArtifactVersion>> scopeToTransitives,
-                    String targetScope,
-                    boolean isGradle) {
+            private Set<TransitiveDependency> getCompatibleTransitives(
+                    Map<String, Set<TransitiveDependency>> scopeToTransitives,
+                    String targetScope) {
 
-                Set<ResolvedGroupArtifactVersion> result = new HashSet<>();
+                Set<TransitiveDependency> result = new HashSet<>();
 
                 // Always include transitives from the same scope
-                Set<ResolvedGroupArtifactVersion> sameScope = scopeToTransitives.get(targetScope);
+                Set<TransitiveDependency> sameScope = scopeToTransitives.get(targetScope);
                 if (sameScope != null) {
                     result.addAll(sameScope);
                 }
 
                 // Include transitives from broader scopes
-                List<String> broaderScopes = isGradle ?
-                        getBroaderGradleScopes(targetScope) :
-                        getBroaderMavenScopes(targetScope);
-                for (String broader : broaderScopes) {
-                    Set<ResolvedGroupArtifactVersion> broaderTransitives = scopeToTransitives.get(broader);
+                for (String broader : getBroaderGradleScopes(targetScope)) {
+                    Set<TransitiveDependency> broaderTransitives = scopeToTransitives.get(broader);
                     if (broaderTransitives != null) {
                         result.addAll(broaderTransitives);
                     }
@@ -309,19 +334,6 @@ public class RemoveRedundantDependencies extends ScanningRecipe<RemoveRedundantD
                     case "testimplementation":
                     case "testruntimeonly":
                         return Arrays.asList("implementation", "api", "testImplementation");
-                    default:
-                        return emptyList();
-                }
-            }
-
-            private List<String> getBroaderMavenScopes(String scope) {
-                switch (scope.toLowerCase()) {
-                    case "runtime":
-                        return singletonList("compile");
-                    case "provided":
-                        return Arrays.asList("compile", "runtime");
-                    case "test":
-                        return Arrays.asList("compile", "runtime", "provided");
                     default:
                         return emptyList();
                 }

--- a/src/test/java/org/openrewrite/java/dependencies/RemoveRedundantDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RemoveRedundantDependenciesTest.java
@@ -312,6 +312,195 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
     }
 
     @Test
+    void keepsTomcatEmbedCoreWhenExclusionsDiffer() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveRedundantDependencies(
+            "org.springframework.boot", "spring-boot-starter-*")),
+          //language=xml
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>3.2.3</version>
+                    <relativePath/>
+                  </parent>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-web</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.tomcat.embed</groupId>
+                      <artifactId>tomcat-embed-core</artifactId>
+                      <exclusions>
+                        <exclusion>
+                          <groupId>org.apache.tomcat</groupId>
+                          <artifactId>tomcat-embed-programmatic</artifactId>
+                        </exclusion>
+                      </exclusions>
+                    </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepsTomcatEmbedCoreWhenDirectHasNoExclusions() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveRedundantDependencies(
+            "org.springframework.boot", "spring-boot-starter-*")),
+          //language=xml
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>3.2.3</version>
+                    <relativePath/>
+                  </parent>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-web</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.tomcat.embed</groupId>
+                      <artifactId>tomcat-embed-core</artifactId>
+                    </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepsDirectCompileJunitJupiterWhenTransitiveIsTestScoped() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveRedundantDependencies(
+            "org.springframework.boot", "spring-boot-starter-*")),
+          //language=xml
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>3.2.3</version>
+                    <relativePath/>
+                  </parent>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.junit.jupiter</groupId>
+                      <artifactId>junit-jupiter</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-test</artifactId>
+                      <scope>test</scope>
+                    </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepsRuntimeTomcatEmbedCoreWhenTransitiveIsCompileScoped() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveRedundantDependencies(
+            "org.springframework.boot", "spring-boot-starter-*")),
+          //language=xml
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>3.2.3</version>
+                    <relativePath/>
+                  </parent>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-web</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.tomcat.embed</groupId>
+                      <artifactId>tomcat-embed-core</artifactId>
+                      <scope>runtime</scope>
+                    </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepsDirectCompileTomcatEmbedCoreWhenProviderIsProvidedScoped() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveRedundantDependencies(
+            "org.springframework.boot", "spring-boot-starter-*")),
+          //language=xml
+          pomXml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.sample</groupId>
+                  <artifactId>sample</artifactId>
+                  <version>1.0-SNAPSHOT</version>
+                  <parent>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-parent</artifactId>
+                    <version>3.2.3</version>
+                    <relativePath/>
+                  </parent>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-web</artifactId>
+                      <scope>provided</scope>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.tomcat.embed</groupId>
+                      <artifactId>tomcat-embed-core</artifactId>
+                    </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void removeRedundantGradleDependency() {
         rewriteRun(
           spec -> spec.beforeRecipe(withToolingApi())

--- a/src/test/java/org/openrewrite/java/dependencies/RemoveRedundantDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/dependencies/RemoveRedundantDependenciesTest.java
@@ -319,8 +319,7 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
           //language=xml
           pomXml(
             """
-              <?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>com.sample</groupId>
                   <artifactId>sample</artifactId>
@@ -361,8 +360,7 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
           //language=xml
           pomXml(
             """
-              <?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>com.sample</groupId>
                   <artifactId>sample</artifactId>
@@ -397,8 +395,7 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
           //language=xml
           pomXml(
             """
-              <?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>com.sample</groupId>
                   <artifactId>sample</artifactId>
@@ -434,8 +431,7 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
           //language=xml
           pomXml(
             """
-              <?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>com.sample</groupId>
                   <artifactId>sample</artifactId>
@@ -471,8 +467,7 @@ class RemoveRedundantDependenciesTest implements RewriteTest {
           //language=xml
           pomXml(
             """
-              <?xml version="1.0" encoding="UTF-8"?>
-              <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>com.sample</groupId>
                   <artifactId>sample</artifactId>


### PR DESCRIPTION
- Fixes openrewrite/rewrite#8235

## Problem

`RemoveRedundantDependencies` removed a direct dependency whenever a matched parent provided the same coordinate transitively, without checking scope or exclusions. This silently changed the effective classpath / exclusion contract whenever the direct declaration carried information the transitive entry did not.

The issue reports five scenarios (all against public Spring Boot starters) where the direct declaration must be kept but was incorrectly removed:

1. Direct dep has *different* exclusions than the transitive one.
2. Direct dep has *no* exclusions but the transitive one does.
3. Direct dep is `compile` while the transitive is `test` (direct is wider).
4. Direct dep is pinned to `runtime` while the transitive is `compile` (direct is narrower — nearest-wins means the direct declaration actually overrides the transitive scope).
5. The providing starter is `provided`, so its transitives are provided-only, but the direct dep is `compile` (wider).

## Fix

A direct dependency is now only removed when the transitive one provides it at the **exact same effective scope** and with the **same exclusions**, so removal never changes the effective classpath:

- Each transitive dependency now tracks its effective exclusions; a direct dependency is redundant only when its exclusions match exactly.
- Maven transitives are keyed by the parent dependency's own effective scope (derived from `getRequested().getScope()`, deduped across the scope buckets a direct dependency appears in) and compared against the direct dependency's effective scope. The previous "broader scope covers narrower" logic is dropped for Maven, since a direct declaration at a different scope is not redundant.

## Tests

Added the five scenarios from the issue as passing tests. All existing tests continue to pass (13 total).