### PR TITLE
Track the Maven UpgradeTransitiveDependencyVersion accumulator type change

### DIFF
--- a/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java
+++ b/src/main/java/org/openrewrite/java/dependencies/UpgradeTransitiveDependencyVersion.java
@@ -21,7 +21,6 @@ import lombok.Getter;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
-import org.openrewrite.maven.AddManagedDependency;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -110,7 +109,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
 
     @Value
     public static class Accumulator {
-        AddManagedDependency.Scanned mavenAccumulator;
+        org.openrewrite.maven.UpgradeTransitiveDependencyVersion.Accumulator mavenAccumulator;
         org.openrewrite.gradle.UpgradeTransitiveDependencyVersion.DependencyVersionState gradleAccumulator;
     }
 


### PR DESCRIPTION
- Companion to openrewrite/rewrite#8342.

That PR changes `rewrite-maven`'s `UpgradeTransitiveDependencyVersion` to scan into its own `Accumulator` instead of `AddManagedDependency.Scanned` (so it can update an existing managed entry in place). This wrapper's `Accumulator.mavenAccumulator` field referenced the old type, so it must be retyped to match or the wrapper fails to compile against the new API.

The delegating scanner/visitor pass the accumulator straight through, so this is a one-line type change.

- > **Merge order:** this must merge after openrewrite/rewrite#8342 publishes a snapshot; until then CI cannot resolve the new `Accumulator` type.